### PR TITLE
Silence GCC 11 warnings

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -116,6 +116,8 @@ static void freverse(char *start, char *end)
     }
 }
 
+#define FBUFFER_APPEND_LONG_BUFFER_SIZE 20
+
 static long fltoa(long number, char *buf)
 {
     static char digits[] = "0123456789";
@@ -125,13 +127,14 @@ static long fltoa(long number, char *buf)
     if (sign < 0) number = -number;
     do *tmp++ = digits[number % 10]; while (number /= 10);
     if (sign < 0) *tmp++ = '-';
+    if (tmp > buf + FBUFFER_APPEND_LONG_BUFFER_SIZE) UNREACHABLE;
     freverse(buf, tmp - 1);
     return tmp - buf;
 }
 
 static void fbuffer_append_long(FBuffer *fb, long number)
 {
-    char buf[20];
+    char buf[FBUFFER_APPEND_LONG_BUFFER_SIZE];
     unsigned long len = fltoa(number, buf);
     fbuffer_append(fb, buf, len);
 }


### PR DESCRIPTION
```
compiling ../../../../ext/json/generator/generator.c
In file included from ../../../../ext/json/generator/generator.c:1:
In function 'freverse',
    inlined from 'fltoa' at ../../../../ext/json/generator/../fbuffer/fbuffer.h:158:5,
    inlined from 'fbuffer_append_long' at ../../../../ext/json/generator/../fbuffer/fbuffer.h:165:25,
    inlined from 'generate_json_fixnum' at ../../../../ext/json/generator/generator.c:974:5,
    inlined from 'generate_json_integer' at ../../../../ext/json/generator/generator.c:987:9,
    inlined from 'mInteger_to_json' at ../../../../ext/json/generator/generator.c:439:5:
../../../../ext/json/generator/../fbuffer/fbuffer.h:145:45: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  145 |         c = *end, *end-- = *start, *start++ = c;
      |                                    ~~~~~~~~~^~~
../../../../ext/json/generator/generator.c: In function 'mInteger_to_json':
../../../../ext/json/generator/../fbuffer/fbuffer.h:164:10: note: at offset 20 into destination object 'buf' of size 20
  164 |     char buf[20];
      |          ^~~
```