### PR TITLE
Optimize option value detection

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -14,7 +14,7 @@ static VALUE mJSON, mExt, mGenerator, cState, mGeneratorMethods, mObject,
 
 static ID i_to_s, i_to_json, i_new, i_indent, i_space, i_space_before,
           i_object_nl, i_array_nl, i_max_nesting, i_allow_nan, i_ascii_only,
-          i_pack, i_unpack, i_create_id, i_extend, i_key_p,
+          i_pack, i_unpack, i_create_id, i_extend,
           i_aref, i_send, i_respond_to_p, i_match, i_keys, i_depth,
           i_buffer_initial_length, i_dup, i_escape_slash;
 
@@ -1598,7 +1598,6 @@ void Init_generator(void)
     i_unpack = rb_intern("unpack");
     i_create_id = rb_intern("create_id");
     i_extend = rb_intern("extend");
-    i_key_p = rb_intern("key?");
     i_aref = rb_intern("[]");
     i_send = rb_intern("__send__");
     i_respond_to_p = rb_intern("respond_to?");

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -20,7 +20,14 @@
 #define rb_obj_instance_variables(object) rb_funcall(object, rb_intern("instance_variables"), 0)
 #endif
 
-#define option_given_p(opts, key) RTEST(rb_funcall(opts, i_key_p, 1, key))
+static VALUE generator_hash_has_key(VALUE hash, VALUE key)
+{
+    if (Qundef == rb_hash_lookup2(hash, key, Qundef)) {
+        return Qtrue;
+    }
+    return Qfalse;
+}
+#define option_given_p(opts, key) RTEST(generator_hash_has_key(opts, key))
 
 /* unicode definitions */
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -94,7 +94,7 @@ static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
 i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
-i_object_class, i_array_class, i_decimal_class, i_key_p,
+i_object_class, i_array_class, i_decimal_class,
 i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
 i_leftshift, i_new, i_try_convert, i_freeze, i_uminus;
 
@@ -3318,7 +3318,6 @@ void Init_parser(void)
 	i_decimal_class = rb_intern("decimal_class");
 	i_match = rb_intern("match");
 	i_match_string = rb_intern("match_string");
-	i_key_p = rb_intern("key?");
 	i_deep_const_get = rb_intern("deep_const_get");
 	i_aset = rb_intern("[]=");
 	i_aref = rb_intern("[]");

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -17,7 +17,14 @@
 # define MAYBE_UNUSED(x) x
 #endif
 
-#define option_given_p(opts, key) RTEST(rb_funcall(opts, i_key_p, 1, key))
+static VALUE parser_hash_has_key(VALUE hash, VALUE key)
+{
+    if (Qundef == rb_hash_lookup2(hash, key, Qundef)) {
+        return Qtrue;
+    }
+    return Qfalse;
+}
+#define option_given_p(opts, key) RTEST(parser_hash_has_key(opts, key))
 
 /* unicode */
 

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -92,7 +92,7 @@ static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
-          i_object_class, i_array_class, i_decimal_class, i_key_p,
+          i_object_class, i_array_class, i_decimal_class,
           i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
           i_leftshift, i_new, i_try_convert, i_freeze, i_uminus;
 
@@ -957,7 +957,6 @@ void Init_parser(void)
     i_decimal_class = rb_intern("decimal_class");
     i_match = rb_intern("match");
     i_match_string = rb_intern("match_string");
-    i_key_p = rb_intern("key?");
     i_deep_const_get = rb_intern("deep_const_get");
     i_aset = rb_intern("[]=");
     i_aref = rb_intern("[]");


### PR DESCRIPTION
This patch introduces functions same as rb_hash_has_key()
to reduce rb_funcall() calling because it has a overhead.

−               | before   | after    | result
--               | --       | --       | --
JSON.parse       | 302.109k | 343.547k | 1.14x
JSON.generate    | 569.705k | 568.668k | −

### Environment
- MacBook Air (M1, 2020)
- macOS 12.0 beta
- Apple M1
- Ruby 3.0.2

### Before
```
Warming up --------------------------------------
          JSON.parse    30.347k i/100ms
       JSON.generate    56.987k i/100ms
Calculating -------------------------------------
          JSON.parse    302.109k (± 0.2%) i/s -      1.517M in   5.022546s
       JSON.generate    569.705k (± 0.2%) i/s -      2.849M in   5.001462s
```

### After
```
Warming up --------------------------------------
          JSON.parse    35.109k i/100ms
       JSON.generate    57.611k i/100ms
Calculating -------------------------------------
          JSON.parse    343.547k (± 0.3%) i/s -      1.720M in   5.007637s
       JSON.generate    568.668k (± 0.3%) i/s -      2.881M in   5.065486s
```

### Test code
```ruby
require 'benchmark/ips'
require 'json'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.report('JSON.parse') { JSON.parse(json, symbolize_names: true) }

  data = JSON.parse(json, symbolize_names: true)
  x.report('JSON.generate') { JSON.generate(json, indent: "\t") }
end
```