### PR TITLE
Relax Pure::Parser's comment regex to allow any characters in a multi-line comment

### DIFF
--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -39,10 +39,7 @@ module JSON
          //[^\n\r]*[\n\r]| # line comments
          /\*               # c-style comments
          (?:
-          [^*/]|        # normal chars
-          /[^*]|        # slashes that do not start a nested comment
-          \*[^/]|       # asterisks that do not end this comment
-          /(?=\*/)      # single slash before this comment's end
+          [\s\S]*?         # any char, repeated lazily
          )*
            \*/               # the End of this comment
            |[ \t\r\n]+       # whitespaces: space, horizontal tab, lf, cr

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -274,6 +274,14 @@ EOT
     json = <<EOT
 {
   "key1":"value1"  /* multi line
+                    // nested eol comment
+                    /* legal nested multi line comment start sequence */
+}
+EOT
+    assert_equal({ "key1" => "value1" }, parse(json))
+    json = <<EOT
+{
+  "key1":"value1"  /* multi line
                    // nested eol comment
                    closed multi comment */
                    and again, throw an Error */


### PR DESCRIPTION
The regex used by `Pure::Parser` for ignoring comments in JSON tries to do some fancy handling to prohibit nested comments, but it causes it to choke on strings that would otherwise be legit (i.e. that can be parsed by `Ext::Parser` or by a C compiler).

For example, a couple strings that are parsed correctly by `Ext::Parser` but not `Pure::Parser`:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/59188756/153486774-cc359856-24bc-46eb-8163-17ca8de42ecd.png">

This is the original regex (visualized by [Regexper](https://regexper.com/#%28%3F%3A%5C%2F%5C%2F%5B%5E%5Cn%5Cr%5D*%5B%5Cn%5Cr%5D%7C%5C%2F%5C*%28%3F%3A%5B%5E*%5C%2F%5D%7C%5C%2F%5B%5E*%5D%7C%5C*%5B%5E%5C%2F%5D%7C%5C%2F%28%3F%3D%5C*%5C%2F%29%29*%5C*%5C%2F%7C%5B%20%5Ct%5Cr%5Cn%5D%2B%29%2B)):
<img width="461" alt="image" src="https://user-images.githubusercontent.com/59188756/153487739-01ee30c3-fe0b-4405-80ba-dab46406cb86.png">


This is the simplified regex after my changes ([Regexper](https://regexper.com/#%28%3F%3A%5C%2F%5C%2F%5B%5E%5Cn%5Cr%5D*%5B%5Cn%5Cr%5D%7C%5C%2F%5C*%28%3F%3A%5B%5Cs%5CS%5D*%3F%29*%5C*%5C%2F%7C%5B%20%5Ct%5Cr%5Cn%5D%2B%29%2B)):
<img width="460" alt="image" src="https://user-images.githubusercontent.com/59188756/153487230-c4e0df1a-0de2-410e-92c2-d3a697724073.png">

I added a test to assert that a comment containing `/*` is parseable. Note that the test case immediately above that change asserts that a nested ANSI C-style comment still triggers an exception.