### PR TITLE
Fix behavior of trying to parse non-string objects

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -20,11 +20,16 @@ module JSON
     #   ruby = [0, 1, nil]
     #   JSON[ruby] # => '[0,1,null]'
     def [](object, opts = {})
-      if object.respond_to? :to_str
-        JSON.parse(object.to_str, opts)
-      else
-        JSON.generate(object, opts)
+      if object.is_a?(String)
+        return JSON.parse(object, opts)
+      elsif object.respond_to?(:to_str)
+        str = object.to_str
+        if str.is_a?(String)
+          return JSON.parse(object.to_str, opts)
+        end
       end
+
+      JSON.generate(object, opts)
     end
 
     # Returns the JSON parser class that is used by JSON. This is either
@@ -693,11 +698,16 @@ module ::Kernel
   # The _opts_ argument is passed through to generate/parse respectively. See
   # generate and parse for their documentation.
   def JSON(object, *args)
-    if object.respond_to? :to_str
-      JSON.parse(object.to_str, args.first)
-    else
-      JSON.generate(object, args.first)
+    if object.is_a?(String)
+      return JSON.parse(object, args.first)
+    elsif object.respond_to?(:to_str)
+      str = object.to_str
+      if str.is_a?(String)
+        return JSON.parse(object.to_str, args.first)
+      end
     end
+
+    JSON.generate(object, args.first)
   end
 end
 

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -6,6 +6,13 @@ require 'tempfile'
 class JSONCommonInterfaceTest < Test::Unit::TestCase
   include JSON
 
+  module MethodMissing
+    def method_missing(name, *args); end
+    def respond_to_missing?(name, include_private)
+      true
+    end
+  end
+
   def setup
     @hash = {
       'a' => 2,
@@ -17,12 +24,26 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
       'h' => 1000.0,
       'i' => 0.001
     }
+
+    @hash_with_method_missing = {
+      'a' => 2,
+      'b' => 3.141,
+      'c' => 'c',
+      'd' => [ 1, "b", 3.14 ],
+      'e' => { 'foo' => 'bar' },
+      'g' => "\"\0\037",
+      'h' => 1000.0,
+      'i' => 0.001
+    }
+    @hash_with_method_missing.extend MethodMissing
+
     @json = '{"a":2,"b":3.141,"c":"c","d":[1,"b",3.14],"e":{"foo":"bar"},'\
       '"g":"\\"\\u0000\\u001f","h":1000.0,"i":0.001}'
   end
 
   def test_index
     assert_equal @json, JSON[@hash]
+    assert_equal @json, JSON[@hash_with_method_missing]
     assert_equal @hash, JSON[@json]
   end
 
@@ -129,6 +150,7 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
 
   def test_JSON
     assert_equal @json, JSON(@hash)
+    assert_equal @json, JSON(@hash_with_method_missing)
     assert_equal @hash, JSON(@json)
   end
 


### PR DESCRIPTION
Some Object may return `true` for `respond_to?(:to_str)` but actually return `nil` instead of String when `to_str` is called.

A good example is the Rails encrypted credentials in Rails 7.0, an object called `InheritableOptions` that extends `Hash`.
`InheritableOptions` implements `method_missing` and returns `true` for `respond_to?(:to_str)` but `nil` when actually calling `to_str`.
https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/ordered_options.rb#L43

Therefore, the following implementation will cause an error.

```rb
h = ActiveSupport::InheritableOptions.new({ a: 1, b: 2 })
h.is_a? Hash #=> true
JSON(h) #=> TypeError: no implicit conversion of nil into String
```

This PR implements strict checking of arguments to avoid this kind of error.