### PR TITLE
When dumping to IO, dump directly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+ext/json/ext/parser/parser.c linguist-generated=true
+java/src/json/ext/Parser.java linguist-generated=true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         - { os: windows-latest, ruby: jruby-head }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby-pkgs@v1
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby-pkgs@v1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+### 2024-11-14 (2.8.2)
+
 * `JSON.load_file` explictly read the file as UTF-8.
 
 ### 2024-11-06 (2.8.1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,15 @@
 # Changes
 
-### UNRELEASED
+### 2024-11-06 (2.8.0)
 
 * Emit a deprecation warning when `JSON.load` create custom types without the `create_additions` option being explictly enabled.
   * Prefer to use `JSON.unsafe_load(string)` or `JSON.load(string, create_additions: true)`.
 * Emit a deprecation warning when serializing valid UTF-8 strings encoded in `ASCII_8BIT` aka `BINARY`.
-* Bump required_ruby_version to 2.7.
-* More performance improvments to `JSON.dump` and `JSON.generate`.
+* Bump required Ruby version to 2.7.
+* Add support for optionally parsing trailing commas, via `allow_trailing_comma: true`, which in cunjunction with the
+  pre-existing support for comments, make it suitable to parse `jsonc` documents.
+* Many performance improvements to `JSON.parse` and `JSON.load`, up to `1.7x` faster on real world documents.
+* Some minor performance improvements to `JSON.dump` and `JSON.generate`.
 
 ### 2024-11-04 (2.7.6)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Fix the java packages to include the extension.
+
 ### 2024-11-06 (2.8.0)
 
 * Emit a deprecation warning when `JSON.load` create custom types without the `create_additions` option being explictly enabled.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+### 2024-11-06 (2.8.1)
+
 * Fix the java packages to include the extension.
 
 ### 2024-11-06 (2.8.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 * Bump required_ruby_version to 2.7.
 * More performance improvments to `JSON.dump` and `JSON.generate`.
 
+### 2024-11-04 (2.7.6)
+
+* Fix a regression in JSON.generate when dealing with Hash keys that are string subclasses, call `to_json` on them.
+
 ### 2024-10-25 (2.7.5)
 
 * Fix a memory leak when `#to_json` methods raise an exception.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* `JSON.load_file` explictly read the file as UTF-8.
+
 ### 2024-11-06 (2.8.1)
 
 * Fix the java packages to include the extension.

--- a/Rakefile
+++ b/Rakefile
@@ -161,7 +161,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   file JRUBY_PARSER_JAR => :compile do
     cd 'java/src' do
       parser_classes = FileList[
-        "json/ext/ByteListTranscoder*.class",
+        "json/ext/ByteList*.class",
         "json/ext/OptionsReader*.class",
         "json/ext/Parser*.class",
         "json/ext/RuntimeInfo*.class",
@@ -179,7 +179,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   file JRUBY_GENERATOR_JAR => :compile do
     cd 'java/src' do
       generator_classes = FileList[
-        "json/ext/ByteListTranscoder*.class",
+        "json/ext/ByteList*.class",
         "json/ext/OptionsReader*.class",
         "json/ext/Generator*.class",
         "json/ext/RuntimeInfo*.class",

--- a/benchmark/parser.rb
+++ b/benchmark/parser.rb
@@ -19,7 +19,7 @@ def benchmark_parsing(name, json_output)
   Benchmark.ips do |x|
     x.report("json")      { JSON.parse(json_output) } if RUN[:json]
     x.report("oj")        { Oj.load(json_output) } if RUN[:oj]
-    x.report("Oj::Parser") { Oj::Parser.usual.parse(json_output) } if RUN[:oj]
+    x.report("Oj::Parser") { Oj::Parser.new(:usual).parse(json_output) } if RUN[:oj]
     x.report("rapidjson") { RapidJSON.parse(json_output) } if RUN[:rapidjson]
     x.compare!(order: :baseline)
   end
@@ -28,10 +28,6 @@ end
 
 # NB: Notes are based on ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
 
-# Oj::Parser is significanly faster (~1.3x) on the next 3 micro-benchmarks in large part because its
-# cache is persisted across calls. That's not something we can do with the current API, we'd
-# need to expose a stateful API as well, but that's no really desirable.
-# Other than that we're faster than regular `Oj.load` by a good margin (between 1.3x and 2.4x).
 benchmark_parsing "small nested array", JSON.dump([[1,2,3,4,5]]*10)
 benchmark_parsing "small hash", JSON.dump({ "username" => "jhawthorn", "id" => 123, "event" => "wrote json serializer" })
 benchmark_parsing "test from oj", <<JSON

--- a/benchmark/parser.rb
+++ b/benchmark/parser.rb
@@ -28,27 +28,26 @@ end
 
 # NB: Notes are based on ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
 
-# Oj::Parser is very significanly faster (1.80x) on the nested array benchmark.
-benchmark_parsing "small nested array", JSON.dump([[1,2,3,4,5]]*10)
-
-# Oj::Parser is significanly faster (~1.5x) on the next 4 benchmarks in large part because its
+# Oj::Parser is significanly faster (~1.3x) on the next 3 micro-benchmarks in large part because its
 # cache is persisted across calls. That's not something we can do with the current API, we'd
 # need to expose a stateful API as well, but that's no really desirable.
-# Other than that we're faster than regular `Oj.load` by a good margin.
+# Other than that we're faster than regular `Oj.load` by a good margin (between 1.3x and 2.4x).
+benchmark_parsing "small nested array", JSON.dump([[1,2,3,4,5]]*10)
 benchmark_parsing "small hash", JSON.dump({ "username" => "jhawthorn", "id" => 123, "event" => "wrote json serializer" })
-
 benchmark_parsing "test from oj", <<JSON
-{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}
+{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],
+"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,
+"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}
 JSON
 
-# On these macro-benchmarks, we're on par with `Oj::Parser` and significantly
-# faster than `Oj.load`.
+# On these macro-benchmarks, we're on par with `Oj::Parser`, except `twitter.json` where we're `1.14x` faster,
+# And between 1.3x and 1.5x faster than `Oj.load`.
 benchmark_parsing "activitypub.json", File.read("#{__dir__}/data/activitypub.json")
 benchmark_parsing "twitter.json", File.read("#{__dir__}/data/twitter.json")
 benchmark_parsing "citm_catalog.json", File.read("#{__dir__}/data/citm_catalog.json")
 
-# rapidjson is 8x faster thanks to it's much more performant float parser.
+# rapidjson is 8x faster thanks to its much more performant float parser.
 # Unfortunately, there isn't a lot of existing fast float parsers in pure C,
 # and including C++ is problematic.
-# Aside from that, we're much faster than other alternatives here.
+# Aside from that, we're close to the alternatives here.
 benchmark_parsing "float parsing", File.read("#{__dir__}/data/canada.json")

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -118,8 +118,8 @@ static void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str, const char esca
                         case '\r': fbuffer_append(out_buffer, "\\r", 2); break;
                         case '\t': fbuffer_append(out_buffer, "\\t", 2); break;
                         default: {
-                            scratch[2] = hexdig[ch >> 12];
-                            scratch[3] = hexdig[(ch >> 8) & 0xf];
+                            scratch[2] = '0';
+                            scratch[3] = '0';
                             scratch[4] = hexdig[(ch >> 4) & 0xf];
                             scratch[5] = hexdig[ch & 0xf];
                             fbuffer_append(out_buffer, scratch, 6);
@@ -240,8 +240,8 @@ static void convert_ASCII_to_JSON(FBuffer *out_buffer, VALUE str, const char esc
                 case '\r': fbuffer_append(out_buffer, "\\r", 2); break;
                 case '\t': fbuffer_append(out_buffer, "\\t", 2); break;
                 default:
-                    scratch[2] = hexdig[ch >> 12];
-                    scratch[3] = hexdig[(ch >> 8) & 0xf];
+                    scratch[2] = '0';
+                    scratch[3] = '0';
                     scratch[4] = hexdig[(ch >> 4) & 0xf];
                     scratch[5] = hexdig[ch & 0xf];
                     fbuffer_append(out_buffer, scratch, 6);
@@ -288,8 +288,8 @@ static void convert_UTF8_to_ASCII_only_JSON(FBuffer *out_buffer, VALUE str, cons
                         case '\r': fbuffer_append(out_buffer, "\\r", 2); break;
                         case '\t': fbuffer_append(out_buffer, "\\t", 2); break;
                         default: {
-                            scratch[2] = hexdig[ch >> 12];
-                            scratch[3] = hexdig[(ch >> 8) & 0xf];
+                            scratch[2] = '0';
+                            scratch[3] = '0';
                             scratch[4] = hexdig[(ch >> 4) & 0xf];
                             scratch[5] = hexdig[ch & 0xf];
                             fbuffer_append(out_buffer, scratch, 6);

--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -5,6 +5,7 @@ have_func("rb_enc_interned_str", "ruby.h") # RUBY_VERSION >= 3.0
 have_func("rb_hash_new_capa", "ruby.h") # RUBY_VERSION >= 3.2
 have_func("rb_gc_mark_locations", "ruby.h") # Missing on TruffleRuby
 have_func("rb_hash_bulk_insert", "ruby.h") # Missing on TruffleRuby
+have_func("rb_category_warn", "ruby.h") # Missing on TruffleRuby
 
 append_cflags("-std=c99")
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -17,6 +17,17 @@ static VALUE sym_max_nesting, sym_allow_nan, sym_allow_trailing_comma, sym_symbo
 static int binary_encindex;
 static int utf8_encindex;
 
+#ifdef HAVE_RB_CATEGORY_WARN
+# define json_deprecated(message) rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, message)
+#else
+# define json_deprecated(message) rb_warn(message)
+#endif
+
+static const char deprecated_create_additions_warning[] =
+    "JSON.load implicit support for `create_additions: true` is deprecated "
+    "and will be removed in 3.0, use JSON.unsafe_load or explicitly "
+    "pass `create_additions: true`";
+
 #ifndef HAVE_RB_GC_MARK_LOCATIONS
 // For TruffleRuby
 void rb_gc_mark_locations(const VALUE *start, const VALUE *end)
@@ -438,11 +449,11 @@ static void raise_parse_error(const char *format, const char *start)
 
 
 
-#line 464 "parser.rl"
+#line 475 "parser.rl"
 
 
 
-#line 446 "parser.c"
+#line 457 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 32};
 enum {JSON_object_error = 0};
@@ -450,7 +461,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 504 "parser.rl"
+#line 515 "parser.rl"
 
 
 #define PUSH(result) rvalue_stack_push(json->stack, result, &json->stack_handle, &json->stack)
@@ -466,14 +477,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     long stack_head = json->stack->head;
 
 
-#line 470 "parser.c"
+#line 481 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 519 "parser.rl"
+#line 530 "parser.rl"
 
-#line 477 "parser.c"
+#line 488 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -502,7 +513,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 483 "parser.rl"
+#line 494 "parser.rl"
 	{
         char *np;
         json->parsing_name = true;
@@ -518,7 +529,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 522 "parser.c"
+#line 533 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -585,7 +596,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 472 "parser.rl"
+#line 483 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, result, current_nesting);
         if (np == NULL) {
@@ -599,20 +610,20 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 603 "parser.c"
+#line 614 "parser.c"
 	_widec = (*p);
 	if ( (*p) < 13 ) {
 		if ( (*p) > 9 ) {
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -620,26 +631,26 @@ case 9:
 			if ( 32 <= (*p) && (*p) <= 32 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) > 44 ) {
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -660,14 +671,14 @@ case 9:
 		goto st10;
 	goto st0;
 tr4:
-#line 494 "parser.rl"
+#line 505 "parser.rl"
 	{ p--; {p++; cs = 32; goto _out;} }
 	goto st32;
 st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 671 "parser.c"
+#line 682 "parser.c"
 	goto st0;
 st10:
 	if ( ++p == pe )
@@ -769,13 +780,13 @@ case 20:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -794,20 +805,20 @@ case 21:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -830,13 +841,13 @@ case 22:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -844,19 +855,19 @@ case 22:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -880,20 +891,20 @@ case 23:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 481 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1007,7 +1018,7 @@ case 31:
 	_out: {}
 	}
 
-#line 520 "parser.rl"
+#line 531 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         long count = json->stack->head - stack_head;
@@ -1045,7 +1056,7 @@ case 31:
                 VALUE klass = rb_funcall(mJSON, i_deep_const_get, 1, klassname);
                 if (RTEST(rb_funcall(klass, i_json_creatable_p, 0))) {
                     if (json->deprecated_create_additions) {
-                        rb_warn("JSON.load implicit support for `create_additions: true` is deprecated and will be removed in 3.0, use JSON.unsafe_load or explicitly pass `create_additions: true`");
+                        json_deprecated(deprecated_create_additions_warning);
                     }
                     *result = rb_funcall(klass, i_json_create, 1, *result);
                 }
@@ -1058,7 +1069,7 @@ case 31:
 }
 
 
-#line 1062 "parser.c"
+#line 1073 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -1066,7 +1077,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 655 "parser.rl"
+#line 666 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1074,14 +1085,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1078 "parser.c"
+#line 1089 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 662 "parser.rl"
+#line 673 "parser.rl"
 
-#line 1085 "parser.c"
+#line 1096 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1115,7 +1126,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 598 "parser.rl"
+#line 609 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) {
@@ -1127,7 +1138,7 @@ tr2:
     }
 	goto st29;
 tr3:
-#line 608 "parser.rl"
+#line 619 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -1151,7 +1162,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 630 "parser.rl"
+#line 641 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -1159,7 +1170,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 636 "parser.rl"
+#line 647 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -1167,7 +1178,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 591 "parser.rl"
+#line 602 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -1177,7 +1188,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 584 "parser.rl"
+#line 595 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -1187,19 +1198,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 578 "parser.rl"
+#line 589 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 575 "parser.rl"
+#line 586 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 581 "parser.rl"
+#line 592 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -1208,9 +1219,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 642 "parser.rl"
+#line 653 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 1214 "parser.c"
+#line 1225 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -1451,7 +1462,7 @@ case 28:
 	_out: {}
 	}
 
-#line 663 "parser.rl"
+#line 674 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -1466,7 +1477,7 @@ case 28:
 }
 
 
-#line 1470 "parser.c"
+#line 1481 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -1474,7 +1485,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 684 "parser.rl"
+#line 695 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1482,15 +1493,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 1486 "parser.c"
+#line 1497 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 691 "parser.rl"
+#line 702 "parser.rl"
     json->memo = p;
 
-#line 1494 "parser.c"
+#line 1505 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1524,14 +1535,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 681 "parser.rl"
+#line 692 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 1535 "parser.c"
+#line 1546 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1550,7 +1561,7 @@ case 5:
 	_out: {}
 	}
 
-#line 693 "parser.rl"
+#line 704 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -1565,7 +1576,7 @@ case 5:
 }
 
 
-#line 1569 "parser.c"
+#line 1580 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -1573,7 +1584,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 718 "parser.rl"
+#line 729 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1581,15 +1592,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1585 "parser.c"
+#line 1596 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 725 "parser.rl"
+#line 736 "parser.rl"
     json->memo = p;
 
-#line 1593 "parser.c"
+#line 1604 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1647,14 +1658,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 712 "parser.rl"
+#line 723 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1658 "parser.c"
+#line 1669 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1715,7 +1726,7 @@ case 7:
 	_out: {}
 	}
 
-#line 727 "parser.rl"
+#line 738 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         VALUE mod = Qnil;
@@ -1768,7 +1779,7 @@ case 7:
 
 
 
-#line 1772 "parser.c"
+#line 1783 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 22};
 enum {JSON_array_error = 0};
@@ -1776,7 +1787,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 804 "parser.rl"
+#line 815 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1789,14 +1800,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     long stack_head = json->stack->head;
 
 
-#line 1793 "parser.c"
+#line 1804 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 816 "parser.rl"
+#line 827 "parser.rl"
 
-#line 1800 "parser.c"
+#line 1811 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -1836,7 +1847,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 784 "parser.rl"
+#line 795 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1851,12 +1862,12 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1855 "parser.c"
+#line 1866 "parser.c"
 	_widec = (*p);
 	if ( 44 <= (*p) && (*p) <= 44 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1903,14 +1914,14 @@ case 7:
 		goto st3;
 	goto st7;
 tr4:
-#line 796 "parser.rl"
+#line 807 "parser.rl"
 	{ p--; {p++; cs = 22; goto _out;} }
 	goto st22;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1914 "parser.c"
+#line 1925 "parser.c"
 	goto st0;
 st8:
 	if ( ++p == pe )
@@ -1978,13 +1989,13 @@ case 13:
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -1992,19 +2003,19 @@ case 13:
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 32 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2043,13 +2054,13 @@ case 14:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2068,20 +2079,20 @@ case 15:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2104,13 +2115,13 @@ case 16:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -2118,19 +2129,19 @@ case 16:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2154,20 +2165,20 @@ case 17:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 794 "parser.rl"
+#line 805 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2239,7 +2250,7 @@ case 21:
 	_out: {}
 	}
 
-#line 817 "parser.rl"
+#line 828 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         long count = json->stack->head - stack_head;
@@ -2413,7 +2424,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
 }
 
 
-#line 2417 "parser.c"
+#line 2428 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -2421,7 +2432,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 1008 "parser.rl"
+#line 1019 "parser.rl"
 
 
 static int
@@ -2442,15 +2453,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 2446 "parser.c"
+#line 2457 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 1028 "parser.rl"
+#line 1039 "parser.rl"
     json->memo = p;
 
-#line 2454 "parser.c"
+#line 2465 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2475,7 +2486,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 995 "parser.rl"
+#line 1006 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         if (NIL_P(*result)) {
@@ -2485,14 +2496,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 1005 "parser.rl"
+#line 1016 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 2496 "parser.c"
+#line 2507 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -2568,7 +2579,7 @@ case 7:
 	_out: {}
 	}
 
-#line 1030 "parser.rl"
+#line 1041 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -2721,7 +2732,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 2725 "parser.c"
+#line 2736 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -2729,7 +2740,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 1196 "parser.rl"
+#line 1207 "parser.rl"
 
 
 /*
@@ -2758,16 +2769,16 @@ static VALUE cParser_parse(VALUE self)
     json->stack = &stack;
 
 
-#line 2762 "parser.c"
+#line 2773 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1224 "parser.rl"
+#line 1235 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2771 "parser.c"
+#line 2782 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2801,7 +2812,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1188 "parser.rl"
+#line 1199 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2811,7 +2822,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2815 "parser.c"
+#line 2826 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2900,7 +2911,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1227 "parser.rl"
+#line 1238 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -2936,16 +2947,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     json->stack = &stack;
 
 
-#line 2940 "parser.c"
+#line 2951 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1262 "parser.rl"
+#line 1273 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2949 "parser.c"
+#line 2960 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2979,7 +2990,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1188 "parser.rl"
+#line 1199 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2989,7 +3000,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2993 "parser.c"
+#line 3004 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -3078,7 +3089,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1265 "parser.rl"
+#line 1276 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -422,7 +422,6 @@ static const rb_data_type_t JSON_Parser_type;
 static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
-static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 
@@ -449,11 +448,11 @@ static void raise_parse_error(const char *format, const char *start)
 
 
 
-#line 475 "parser.rl"
+#line 474 "parser.rl"
 
 
 
-#line 457 "parser.c"
+#line 456 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 32};
 enum {JSON_object_error = 0};
@@ -461,7 +460,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 515 "parser.rl"
+#line 514 "parser.rl"
 
 
 #define PUSH(result) rvalue_stack_push(json->stack, result, &json->stack_handle, &json->stack)
@@ -477,14 +476,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     long stack_head = json->stack->head;
 
 
-#line 481 "parser.c"
+#line 480 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 530 "parser.rl"
+#line 529 "parser.rl"
 
-#line 488 "parser.c"
+#line 487 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -513,7 +512,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 494 "parser.rl"
+#line 493 "parser.rl"
 	{
         char *np;
         json->parsing_name = true;
@@ -529,7 +528,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 533 "parser.c"
+#line 532 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -596,7 +595,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 483 "parser.rl"
+#line 482 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, result, current_nesting);
         if (np == NULL) {
@@ -610,20 +609,20 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 614 "parser.c"
+#line 613 "parser.c"
 	_widec = (*p);
 	if ( (*p) < 13 ) {
 		if ( (*p) > 9 ) {
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -631,26 +630,26 @@ case 9:
 			if ( 32 <= (*p) && (*p) <= 32 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) > 44 ) {
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -671,14 +670,14 @@ case 9:
 		goto st10;
 	goto st0;
 tr4:
-#line 505 "parser.rl"
+#line 504 "parser.rl"
 	{ p--; {p++; cs = 32; goto _out;} }
 	goto st32;
 st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 682 "parser.c"
+#line 681 "parser.c"
 	goto st0;
 st10:
 	if ( ++p == pe )
@@ -780,13 +779,13 @@ case 20:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -805,20 +804,20 @@ case 21:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -841,13 +840,13 @@ case 22:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -855,19 +854,19 @@ case 22:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -891,20 +890,20 @@ case 23:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 492 "parser.rl"
+#line 491 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1018,7 +1017,7 @@ case 31:
 	_out: {}
 	}
 
-#line 531 "parser.rl"
+#line 530 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         long count = json->stack->head - stack_head;
@@ -1069,7 +1068,7 @@ case 31:
 }
 
 
-#line 1073 "parser.c"
+#line 1072 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -1077,7 +1076,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 666 "parser.rl"
+#line 661 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1085,14 +1084,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1089 "parser.c"
+#line 1088 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 673 "parser.rl"
+#line 668 "parser.rl"
 
-#line 1096 "parser.c"
+#line 1095 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1126,7 +1125,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 609 "parser.rl"
+#line 608 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) {
@@ -1138,7 +1137,7 @@ tr2:
     }
 	goto st29;
 tr3:
-#line 619 "parser.rl"
+#line 618 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -1154,15 +1153,11 @@ tr3:
         if (np != NULL) {
             {p = (( np))-1;}
         }
-        np = JSON_parse_integer(json, p, pe, result);
-        if (np != NULL) {
-            {p = (( np))-1;}
-        }
         p--; {p++; cs = 29; goto _out;}
     }
 	goto st29;
 tr7:
-#line 641 "parser.rl"
+#line 636 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -1170,7 +1165,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 647 "parser.rl"
+#line 642 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -1178,7 +1173,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 602 "parser.rl"
+#line 601 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -1188,7 +1183,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 595 "parser.rl"
+#line 594 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -1198,19 +1193,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 589 "parser.rl"
+#line 588 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 586 "parser.rl"
+#line 585 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 592 "parser.rl"
+#line 591 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -1219,9 +1214,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 653 "parser.rl"
+#line 648 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 1225 "parser.c"
+#line 1220 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -1462,7 +1457,7 @@ case 28:
 	_out: {}
 	}
 
-#line 674 "parser.rl"
+#line 669 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -1477,7 +1472,7 @@ case 28:
 }
 
 
-#line 1481 "parser.c"
+#line 1476 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -1485,7 +1480,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 695 "parser.rl"
+#line 690 "parser.rl"
 
 
 #define MAX_FAST_INTEGER_SIZE 18
@@ -1510,82 +1505,8 @@ static inline VALUE fast_parse_integer(char *p, char *pe)
     return LL2NUM(memo);
 }
 
-static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
+static char *JSON_decode_integer(JSON_Parser *json, char *p, VALUE *result)
 {
-    int cs = EVIL;
-
-
-#line 1519 "parser.c"
-	{
-	cs = JSON_integer_start;
-	}
-
-#line 724 "parser.rl"
-    json->memo = p;
-
-#line 1527 "parser.c"
-	{
-	if ( p == pe )
-		goto _test_eof;
-	switch ( cs )
-	{
-case 1:
-	switch( (*p) ) {
-		case 45: goto st2;
-		case 48: goto st3;
-	}
-	if ( 49 <= (*p) && (*p) <= 57 )
-		goto st5;
-	goto st0;
-st0:
-cs = 0;
-	goto _out;
-st2:
-	if ( ++p == pe )
-		goto _test_eof2;
-case 2:
-	if ( (*p) == 48 )
-		goto st3;
-	if ( 49 <= (*p) && (*p) <= 57 )
-		goto st5;
-	goto st0;
-st3:
-	if ( ++p == pe )
-		goto _test_eof3;
-case 3:
-	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st0;
-	goto tr4;
-tr4:
-#line 692 "parser.rl"
-	{ p--; {p++; cs = 4; goto _out;} }
-	goto st4;
-st4:
-	if ( ++p == pe )
-		goto _test_eof4;
-case 4:
-#line 1568 "parser.c"
-	goto st0;
-st5:
-	if ( ++p == pe )
-		goto _test_eof5;
-case 5:
-	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st5;
-	goto tr4;
-	}
-	_test_eof2: cs = 2; goto _test_eof;
-	_test_eof3: cs = 3; goto _test_eof;
-	_test_eof4: cs = 4; goto _test_eof;
-	_test_eof5: cs = 5; goto _test_eof;
-
-	_test_eof: {}
-	_out: {}
-	}
-
-#line 726 "parser.rl"
-
-    if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
         if (RB_LIKELY(len < MAX_FAST_INTEGER_SIZE)) {
             *result = fast_parse_integer(json->memo, p);
@@ -1596,37 +1517,35 @@ case 5:
             *result = rb_cstr2inum(FBUFFER_PTR(&json->fbuffer), 10);
         }
         return p + 1;
-    } else {
-        return NULL;
-    }
 }
 
 
-#line 1606 "parser.c"
+#line 1524 "parser.c"
 enum {JSON_float_start = 1};
-enum {JSON_float_first_final = 8};
+enum {JSON_float_first_final = 6};
 enum {JSON_float_error = 0};
 
 enum {JSON_float_en_main = 1};
 
 
-#line 755 "parser.rl"
+#line 742 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
 {
     int cs = EVIL;
+    bool is_float = false;
 
 
-#line 1622 "parser.c"
+#line 1541 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 762 "parser.rl"
+#line 750 "parser.rl"
     json->memo = p;
 
-#line 1630 "parser.c"
+#line 1549 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1635,10 +1554,10 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
 case 1:
 	switch( (*p) ) {
 		case 45: goto st2;
-		case 48: goto st3;
+		case 48: goto st6;
 	}
 	if ( 49 <= (*p) && (*p) <= 57 )
-		goto st7;
+		goto st10;
 	goto st0;
 st0:
 cs = 0;
@@ -1648,24 +1567,42 @@ st2:
 		goto _test_eof2;
 case 2:
 	if ( (*p) == 48 )
-		goto st3;
+		goto st6;
 	if ( 49 <= (*p) && (*p) <= 57 )
-		goto st7;
+		goto st10;
 	goto st0;
+st6:
+	if ( ++p == pe )
+		goto _test_eof6;
+case 6:
+	switch( (*p) ) {
+		case 45: goto st0;
+		case 46: goto tr8;
+		case 69: goto tr9;
+		case 101: goto tr9;
+	}
+	if ( 48 <= (*p) && (*p) <= 57 )
+		goto st0;
+	goto tr7;
+tr7:
+#line 734 "parser.rl"
+	{ p--; {p++; cs = 7; goto _out;} }
+	goto st7;
+st7:
+	if ( ++p == pe )
+		goto _test_eof7;
+case 7:
+#line 1596 "parser.c"
+	goto st0;
+tr8:
+#line 735 "parser.rl"
+	{  is_float = true; }
+	goto st3;
 st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-	switch( (*p) ) {
-		case 46: goto st4;
-		case 69: goto st5;
-		case 101: goto st5;
-	}
-	goto st0;
-st4:
-	if ( ++p == pe )
-		goto _test_eof4;
-case 4:
+#line 1606 "parser.c"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto st8;
 	goto st0;
@@ -1674,87 +1611,86 @@ st8:
 		goto _test_eof8;
 case 8:
 	switch( (*p) ) {
-		case 69: goto st5;
-		case 101: goto st5;
+		case 69: goto st4;
+		case 101: goto st4;
 	}
 	if ( (*p) > 46 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto st8;
 	} else if ( (*p) >= 45 )
 		goto st0;
-	goto tr9;
+	goto tr7;
 tr9:
-#line 749 "parser.rl"
-	{ p--; {p++; cs = 9; goto _out;} }
-	goto st9;
-st9:
+#line 735 "parser.rl"
+	{  is_float = true; }
+	goto st4;
+st4:
 	if ( ++p == pe )
-		goto _test_eof9;
-case 9:
-#line 1695 "parser.c"
+		goto _test_eof4;
+case 4:
+#line 1632 "parser.c"
+	switch( (*p) ) {
+		case 43: goto st5;
+		case 45: goto st5;
+	}
+	if ( 48 <= (*p) && (*p) <= 57 )
+		goto st9;
 	goto st0;
 st5:
 	if ( ++p == pe )
 		goto _test_eof5;
 case 5:
-	switch( (*p) ) {
-		case 43: goto st6;
-		case 45: goto st6;
-	}
 	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st10;
+		goto st9;
 	goto st0;
-st6:
+st9:
 	if ( ++p == pe )
-		goto _test_eof6;
-case 6:
-	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st10;
-	goto st0;
-st10:
-	if ( ++p == pe )
-		goto _test_eof10;
-case 10:
+		goto _test_eof9;
+case 9:
 	switch( (*p) ) {
 		case 69: goto st0;
 		case 101: goto st0;
 	}
 	if ( (*p) > 46 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
-			goto st10;
+			goto st9;
 	} else if ( (*p) >= 45 )
 		goto st0;
-	goto tr9;
-st7:
+	goto tr7;
+st10:
 	if ( ++p == pe )
-		goto _test_eof7;
-case 7:
+		goto _test_eof10;
+case 10:
 	switch( (*p) ) {
-		case 46: goto st4;
-		case 69: goto st5;
-		case 101: goto st5;
+		case 45: goto st0;
+		case 46: goto tr8;
+		case 69: goto tr9;
+		case 101: goto tr9;
 	}
 	if ( 48 <= (*p) && (*p) <= 57 )
-		goto st7;
-	goto st0;
+		goto st10;
+	goto tr7;
 	}
 	_test_eof2: cs = 2; goto _test_eof;
-	_test_eof3: cs = 3; goto _test_eof;
-	_test_eof4: cs = 4; goto _test_eof;
-	_test_eof8: cs = 8; goto _test_eof;
-	_test_eof9: cs = 9; goto _test_eof;
-	_test_eof5: cs = 5; goto _test_eof;
 	_test_eof6: cs = 6; goto _test_eof;
-	_test_eof10: cs = 10; goto _test_eof;
 	_test_eof7: cs = 7; goto _test_eof;
+	_test_eof3: cs = 3; goto _test_eof;
+	_test_eof8: cs = 8; goto _test_eof;
+	_test_eof4: cs = 4; goto _test_eof;
+	_test_eof5: cs = 5; goto _test_eof;
+	_test_eof9: cs = 9; goto _test_eof;
+	_test_eof10: cs = 10; goto _test_eof;
 
 	_test_eof: {}
 	_out: {}
 	}
 
-#line 764 "parser.rl"
+#line 752 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
+        if (!is_float) {
+            return JSON_decode_integer(json, p, result);
+        }
         VALUE mod = Qnil;
         ID method_id = 0;
         if (json->decimal_class) {
@@ -1805,7 +1741,7 @@ case 7:
 
 
 
-#line 1809 "parser.c"
+#line 1745 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 22};
 enum {JSON_array_error = 0};
@@ -1813,7 +1749,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 841 "parser.rl"
+#line 832 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1826,14 +1762,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     long stack_head = json->stack->head;
 
 
-#line 1830 "parser.c"
+#line 1766 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 853 "parser.rl"
+#line 844 "parser.rl"
 
-#line 1837 "parser.c"
+#line 1773 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -1873,7 +1809,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 821 "parser.rl"
+#line 812 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1888,12 +1824,12 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1892 "parser.c"
+#line 1828 "parser.c"
 	_widec = (*p);
 	if ( 44 <= (*p) && (*p) <= 44 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1940,14 +1876,14 @@ case 7:
 		goto st3;
 	goto st7;
 tr4:
-#line 833 "parser.rl"
+#line 824 "parser.rl"
 	{ p--; {p++; cs = 22; goto _out;} }
 	goto st22;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1951 "parser.c"
+#line 1887 "parser.c"
 	goto st0;
 st8:
 	if ( ++p == pe )
@@ -2015,13 +1951,13 @@ case 13:
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -2029,19 +1965,19 @@ case 13:
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 32 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2080,13 +2016,13 @@ case 14:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2105,20 +2041,20 @@ case 15:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2141,13 +2077,13 @@ case 16:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -2155,19 +2091,19 @@ case 16:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2191,20 +2127,20 @@ case 17:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 831 "parser.rl"
+#line 822 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2276,7 +2212,7 @@ case 21:
 	_out: {}
 	}
 
-#line 854 "parser.rl"
+#line 845 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         long count = json->stack->head - stack_head;
@@ -2470,7 +2406,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
 }
 
 
-#line 2474 "parser.c"
+#line 2410 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 9};
 enum {JSON_string_error = 0};
@@ -2478,7 +2414,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 1077 "parser.rl"
+#line 1068 "parser.rl"
 
 
 static int
@@ -2499,15 +2435,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 2503 "parser.c"
+#line 2439 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 1097 "parser.rl"
+#line 1088 "parser.rl"
     json->memo = p;
 
-#line 2511 "parser.c"
+#line 2447 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2532,14 +2468,14 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 1059 "parser.rl"
+#line 1050 "parser.rl"
 	{
         *result = json_string_fastpath(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
         p--;
         {p++; cs = 9; goto _out;}
     }
-#line 1052 "parser.rl"
+#line 1043 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2548,7 +2484,7 @@ tr2:
     }
 	goto st9;
 tr6:
-#line 1052 "parser.rl"
+#line 1043 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2560,7 +2496,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 2564 "parser.c"
+#line 2500 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -2648,7 +2584,7 @@ case 8:
 	_out: {}
 	}
 
-#line 1099 "parser.rl"
+#line 1090 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -2801,7 +2737,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 2805 "parser.c"
+#line 2741 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -2809,7 +2745,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 1265 "parser.rl"
+#line 1256 "parser.rl"
 
 
 /*
@@ -2838,16 +2774,16 @@ static VALUE cParser_parse(VALUE self)
     json->stack = &stack;
 
 
-#line 2842 "parser.c"
+#line 2778 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1293 "parser.rl"
+#line 1284 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2851 "parser.c"
+#line 2787 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2881,7 +2817,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1257 "parser.rl"
+#line 1248 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2891,7 +2827,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2895 "parser.c"
+#line 2831 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2980,7 +2916,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1296 "parser.rl"
+#line 1287 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -3016,16 +2952,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     json->stack = &stack;
 
 
-#line 3020 "parser.c"
+#line 2956 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1331 "parser.rl"
+#line 1322 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 3029 "parser.c"
+#line 2965 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -3059,7 +2995,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1257 "parser.rl"
+#line 1248 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -3069,7 +3005,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 3073 "parser.c"
+#line 3009 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -3158,7 +3094,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1334 "parser.rl"
+#line 1325 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -422,7 +422,7 @@ static const rb_data_type_t JSON_Parser_type;
 static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
-static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result);
+static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 
 
@@ -1149,7 +1149,7 @@ tr3:
                 raise_parse_error("unexpected token at '%s'", p);
             }
         }
-        np = JSON_parse_float(json, p, pe, result);
+        np = JSON_parse_number(json, p, pe, result);
         if (np != NULL) {
             {p = (( np))-1;}
         }
@@ -1531,7 +1531,7 @@ enum {JSON_float_en_main = 1};
 #line 742 "parser.rl"
 
 
-static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
+static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result)
 {
     int cs = EVIL;
     bool is_float = false;

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -394,6 +394,7 @@ typedef struct JSON_ParserStruct {
     VALUE decimal_class;
     VALUE match_string;
     FBuffer fbuffer;
+    int in_array;
     int max_nesting;
     bool allow_nan;
     bool allow_trailing_comma;
@@ -448,11 +449,11 @@ static void raise_parse_error(const char *format, const char *start)
 
 
 
-#line 474 "parser.rl"
+#line 475 "parser.rl"
 
 
 
-#line 456 "parser.c"
+#line 457 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 32};
 enum {JSON_object_error = 0};
@@ -460,7 +461,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 514 "parser.rl"
+#line 515 "parser.rl"
 
 
 #define PUSH(result) rvalue_stack_push(json->stack, result, &json->stack_handle, &json->stack)
@@ -476,14 +477,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     long stack_head = json->stack->head;
 
 
-#line 480 "parser.c"
+#line 481 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 529 "parser.rl"
+#line 530 "parser.rl"
 
-#line 487 "parser.c"
+#line 488 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -512,7 +513,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 493 "parser.rl"
+#line 494 "parser.rl"
 	{
         char *np;
         json->parsing_name = true;
@@ -528,7 +529,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 532 "parser.c"
+#line 533 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -595,7 +596,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 482 "parser.rl"
+#line 483 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, result, current_nesting);
         if (np == NULL) {
@@ -609,20 +610,20 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 613 "parser.c"
+#line 614 "parser.c"
 	_widec = (*p);
 	if ( (*p) < 13 ) {
 		if ( (*p) > 9 ) {
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -630,26 +631,26 @@ case 9:
 			if ( 32 <= (*p) && (*p) <= 32 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) > 44 ) {
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -670,14 +671,14 @@ case 9:
 		goto st10;
 	goto st0;
 tr4:
-#line 504 "parser.rl"
+#line 505 "parser.rl"
 	{ p--; {p++; cs = 32; goto _out;} }
 	goto st32;
 st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 681 "parser.c"
+#line 682 "parser.c"
 	goto st0;
 st10:
 	if ( ++p == pe )
@@ -779,13 +780,13 @@ case 20:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -804,20 +805,20 @@ case 21:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -840,13 +841,13 @@ case 22:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -854,19 +855,19 @@ case 22:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -890,20 +891,20 @@ case 23:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 491 "parser.rl"
+#line 492 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1017,7 +1018,7 @@ case 31:
 	_out: {}
 	}
 
-#line 530 "parser.rl"
+#line 531 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         long count = json->stack->head - stack_head;
@@ -1068,7 +1069,7 @@ case 31:
 }
 
 
-#line 1072 "parser.c"
+#line 1073 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -1076,7 +1077,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 661 "parser.rl"
+#line 664 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1084,14 +1085,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1088 "parser.c"
+#line 1089 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 668 "parser.rl"
+#line 671 "parser.rl"
 
-#line 1095 "parser.c"
+#line 1096 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1125,7 +1126,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 608 "parser.rl"
+#line 609 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) {
@@ -1137,7 +1138,7 @@ tr2:
     }
 	goto st29;
 tr3:
-#line 618 "parser.rl"
+#line 619 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -1157,15 +1158,17 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 636 "parser.rl"
+#line 637 "parser.rl"
 	{
         char *np;
+        json->in_array++;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
+        json->in_array--;
         if (np == NULL) { p--; {p++; cs = 29; goto _out;} } else {p = (( np))-1;}
     }
 	goto st29;
 tr11:
-#line 642 "parser.rl"
+#line 645 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -1173,7 +1176,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 601 "parser.rl"
+#line 602 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -1183,7 +1186,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 594 "parser.rl"
+#line 595 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -1193,19 +1196,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 588 "parser.rl"
+#line 589 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 585 "parser.rl"
+#line 586 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 591 "parser.rl"
+#line 592 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -1214,9 +1217,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 648 "parser.rl"
+#line 651 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 1220 "parser.c"
+#line 1223 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -1457,7 +1460,7 @@ case 28:
 	_out: {}
 	}
 
-#line 669 "parser.rl"
+#line 672 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -1472,7 +1475,7 @@ case 28:
 }
 
 
-#line 1476 "parser.c"
+#line 1479 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -1480,7 +1483,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 690 "parser.rl"
+#line 693 "parser.rl"
 
 
 #define MAX_FAST_INTEGER_SIZE 18
@@ -1520,7 +1523,7 @@ static char *JSON_decode_integer(JSON_Parser *json, char *p, VALUE *result)
 }
 
 
-#line 1524 "parser.c"
+#line 1527 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 6};
 enum {JSON_float_error = 0};
@@ -1528,7 +1531,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 742 "parser.rl"
+#line 745 "parser.rl"
 
 
 static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1537,15 +1540,15 @@ static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *resu
     bool is_float = false;
 
 
-#line 1541 "parser.c"
+#line 1544 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 750 "parser.rl"
+#line 753 "parser.rl"
     json->memo = p;
 
-#line 1549 "parser.c"
+#line 1552 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1585,24 +1588,24 @@ case 6:
 		goto st0;
 	goto tr7;
 tr7:
-#line 734 "parser.rl"
+#line 737 "parser.rl"
 	{ p--; {p++; cs = 7; goto _out;} }
 	goto st7;
 st7:
 	if ( ++p == pe )
 		goto _test_eof7;
 case 7:
-#line 1596 "parser.c"
+#line 1599 "parser.c"
 	goto st0;
 tr8:
-#line 735 "parser.rl"
+#line 738 "parser.rl"
 	{  is_float = true; }
 	goto st3;
 st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1606 "parser.c"
+#line 1609 "parser.c"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto st8;
 	goto st0;
@@ -1621,14 +1624,14 @@ case 8:
 		goto st0;
 	goto tr7;
 tr9:
-#line 735 "parser.rl"
+#line 738 "parser.rl"
 	{  is_float = true; }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 1632 "parser.c"
+#line 1635 "parser.c"
 	switch( (*p) ) {
 		case 43: goto st5;
 		case 45: goto st5;
@@ -1685,7 +1688,7 @@ case 10:
 	_out: {}
 	}
 
-#line 752 "parser.rl"
+#line 755 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         if (!is_float) {
@@ -1741,7 +1744,7 @@ case 10:
 
 
 
-#line 1745 "parser.c"
+#line 1748 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 22};
 enum {JSON_array_error = 0};
@@ -1749,7 +1752,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 832 "parser.rl"
+#line 835 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1762,14 +1765,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     long stack_head = json->stack->head;
 
 
-#line 1766 "parser.c"
+#line 1769 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 844 "parser.rl"
+#line 847 "parser.rl"
 
-#line 1773 "parser.c"
+#line 1776 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -1809,7 +1812,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 812 "parser.rl"
+#line 815 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1824,12 +1827,12 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1828 "parser.c"
+#line 1831 "parser.c"
 	_widec = (*p);
 	if ( 44 <= (*p) && (*p) <= 44 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1876,14 +1879,14 @@ case 7:
 		goto st3;
 	goto st7;
 tr4:
-#line 824 "parser.rl"
+#line 827 "parser.rl"
 	{ p--; {p++; cs = 22; goto _out;} }
 	goto st22;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1887 "parser.c"
+#line 1890 "parser.c"
 	goto st0;
 st8:
 	if ( ++p == pe )
@@ -1951,13 +1954,13 @@ case 13:
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -1965,19 +1968,19 @@ case 13:
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 32 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2016,13 +2019,13 @@ case 14:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2041,20 +2044,20 @@ case 15:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2077,13 +2080,13 @@ case 16:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -2091,19 +2094,19 @@ case 16:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2127,20 +2130,20 @@ case 17:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 822 "parser.rl"
+#line 825 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2212,7 +2215,7 @@ case 21:
 	_out: {}
 	}
 
-#line 845 "parser.rl"
+#line 848 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         long count = json->stack->head - stack_head;
@@ -2268,7 +2271,7 @@ static VALUE json_string_fastpath(JSON_Parser *json, char *string, char *stringE
 {
     size_t bufferSize = stringEnd - string;
 
-    if (is_name) {
+    if (is_name && json->in_array) {
         VALUE cached_key;
         if (RB_UNLIKELY(symbolize)) {
             cached_key = rsymbol_cache_fetch(&json->name_cache, string, bufferSize);
@@ -2291,7 +2294,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
     int unescape_len;
     char buf[4];
 
-    if (is_name) {
+    if (is_name && json->in_array) {
         VALUE cached_key;
         if (RB_UNLIKELY(symbolize)) {
             cached_key = rsymbol_cache_fetch(&json->name_cache, string, bufferSize);
@@ -2406,7 +2409,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
 }
 
 
-#line 2410 "parser.c"
+#line 2413 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 9};
 enum {JSON_string_error = 0};
@@ -2414,7 +2417,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 1068 "parser.rl"
+#line 1071 "parser.rl"
 
 
 static int
@@ -2435,15 +2438,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 2439 "parser.c"
+#line 2442 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 1088 "parser.rl"
+#line 1091 "parser.rl"
     json->memo = p;
 
-#line 2447 "parser.c"
+#line 2450 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2468,14 +2471,14 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 1050 "parser.rl"
+#line 1053 "parser.rl"
 	{
         *result = json_string_fastpath(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
         p--;
         {p++; cs = 9; goto _out;}
     }
-#line 1043 "parser.rl"
+#line 1046 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2484,7 +2487,7 @@ tr2:
     }
 	goto st9;
 tr6:
-#line 1043 "parser.rl"
+#line 1046 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2496,7 +2499,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 2500 "parser.c"
+#line 2503 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -2584,7 +2587,7 @@ case 8:
 	_out: {}
 	}
 
-#line 1090 "parser.rl"
+#line 1093 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -2737,7 +2740,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 2741 "parser.c"
+#line 2744 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -2745,7 +2748,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 1256 "parser.rl"
+#line 1259 "parser.rl"
 
 
 /*
@@ -2774,16 +2777,16 @@ static VALUE cParser_parse(VALUE self)
     json->stack = &stack;
 
 
-#line 2778 "parser.c"
+#line 2781 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1284 "parser.rl"
+#line 1287 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2787 "parser.c"
+#line 2790 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2817,7 +2820,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1248 "parser.rl"
+#line 1251 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2827,7 +2830,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2831 "parser.c"
+#line 2834 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2916,7 +2919,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1287 "parser.rl"
+#line 1290 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -2952,16 +2955,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     json->stack = &stack;
 
 
-#line 2956 "parser.c"
+#line 2959 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1322 "parser.rl"
+#line 1325 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2965 "parser.c"
+#line 2968 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2995,7 +2998,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1248 "parser.rl"
+#line 1251 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -3005,7 +3008,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 3009 "parser.c"
+#line 3012 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -3094,7 +3097,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1325 "parser.rl"
+#line 1328 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -15,6 +15,17 @@ static VALUE sym_max_nesting, sym_allow_nan, sym_allow_trailing_comma, sym_symbo
 static int binary_encindex;
 static int utf8_encindex;
 
+#ifdef HAVE_RB_CATEGORY_WARN
+# define json_deprecated(message) rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, message)
+#else
+# define json_deprecated(message) rb_warn(message)
+#endif
+
+static const char deprecated_create_additions_warning[] =
+    "JSON.load implicit support for `create_additions: true` is deprecated "
+    "and will be removed in 3.0, use JSON.unsafe_load or explicitly "
+    "pass `create_additions: true`";
+
 #ifndef HAVE_RB_GC_MARK_LOCATIONS
 // For TruffleRuby
 void rb_gc_mark_locations(const VALUE *start, const VALUE *end)
@@ -554,7 +565,7 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
                 VALUE klass = rb_funcall(mJSON, i_deep_const_get, 1, klassname);
                 if (RTEST(rb_funcall(klass, i_json_creatable_p, 0))) {
                     if (json->deprecated_create_additions) {
-                        rb_warn("JSON.load implicit support for `create_additions: true` is deprecated and will be removed in 3.0, use JSON.unsafe_load or explicitly pass `create_additions: true`");
+                        json_deprecated(deprecated_create_additions_warning);
                     }
                     *result = rb_funcall(klass, i_json_create, 1, *result);
                 }

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -420,7 +420,7 @@ static const rb_data_type_t JSON_Parser_type;
 static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
-static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result);
+static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result);
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 
 
@@ -626,7 +626,7 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
                 raise_parse_error("unexpected token at '%s'", p);
             }
         }
-        np = JSON_parse_float(json, fpc, pe, result);
+        np = JSON_parse_number(json, fpc, pe, result);
         if (np != NULL) {
             fexec np;
         }
@@ -741,7 +741,7 @@ static char *JSON_decode_integer(JSON_Parser *json, char *p, VALUE *result)
               ) (^[0-9Ee.\-]? @exit ));
 }%%
 
-static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
+static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result)
 {
     int cs = EVIL;
     bool is_float = false;

--- a/java/src/json/ext/ByteListDirectOutputStream.java
+++ b/java/src/json/ext/ByteListDirectOutputStream.java
@@ -1,0 +1,16 @@
+package json.ext;
+
+import org.jcodings.Encoding;
+import org.jruby.util.ByteList;
+
+import java.io.ByteArrayOutputStream;
+
+public class ByteListDirectOutputStream extends ByteArrayOutputStream {
+    ByteListDirectOutputStream(int size) {
+        super(size);
+    }
+
+    public ByteList toByteListDirect(Encoding encoding) {
+        return new ByteList(buf, 0, count, encoding, false);
+    }
+}

--- a/java/src/json/ext/ByteListTranscoder.java
+++ b/java/src/json/ext/ByteListTranscoder.java
@@ -9,6 +9,9 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 /**
  * A class specialized in transcoding a certain String format into another,
  * using UTF-8 ByteLists as both input and output.
@@ -23,7 +26,7 @@ abstract class ByteListTranscoder {
     /** Position of the next character to read */
     protected int pos;
 
-    private ByteList out;
+    private OutputStream out;
     /**
      * When a character that can be copied straight into the output is found,
      * its index is stored on this variable, and copying is delayed until
@@ -37,11 +40,11 @@ abstract class ByteListTranscoder {
         this.context = context;
     }
 
-    protected void init(ByteList src, ByteList out) {
+    protected void init(ByteList src, OutputStream out) {
         this.init(src, 0, src.length(), out);
     }
 
-    protected void init(ByteList src, int start, int end, ByteList out) {
+    protected void init(ByteList src, int start, int end, OutputStream out) {
         this.src = src;
         this.pos = start;
         this.charStart = start;
@@ -142,19 +145,19 @@ abstract class ByteListTranscoder {
      *               recently read character, or {@link #charStart} to quote
      *               until the character before it.
      */
-    protected void quoteStop(int endPos) {
+    protected void quoteStop(int endPos) throws IOException {
         if (quoteStart != -1) {
-            out.append(src, quoteStart, endPos - quoteStart);
+            out.write(src.bytes(), quoteStart, endPos - quoteStart);
             quoteStart = -1;
         }
     }
 
-    protected void append(int b) {
-        out.append(b);
+    protected void append(int b) throws IOException {
+        out.write(b);
     }
 
-    protected void append(byte[] origin, int start, int length) {
-        out.append(origin, start, length);
+    protected void append(byte[] origin, int start, int length) throws IOException {
+        out.write(origin, start, length);
     }
 
 

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -59,11 +59,16 @@ public final class Generator {
      */
     public static <T extends IRubyObject> IRubyObject
             generateJson(ThreadContext context, T object,
-                         GeneratorState config) {
+                         GeneratorState config, IRubyObject io) {
         Session session = new Session(context, config);
         Handler<? super T> handler = getHandlerFor(context.runtime, object);
 
-        return handler.generateNew(session, object);
+        if (io.isNil()) {
+            return handler.generateNew(session, object);
+        }
+
+        handler.generateToBuffer(session, object, new IOOutputStream(io));
+        return io;
     }
 
     /**

--- a/java/src/json/ext/GeneratorService.java
+++ b/java/src/json/ext/GeneratorService.java
@@ -37,6 +37,8 @@ public class GeneratorService implements BasicLibraryService {
             generatorModule.defineModuleUnder("GeneratorMethods");
         GeneratorMethods.populate(info, generatorMethods);
 
+        runtime.getLoadService().require("json/ext/generator/state");
+
         return true;
     }
 }

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -230,15 +230,21 @@ public class GeneratorState extends RubyObject {
      */
     @JRubyMethod
     public IRubyObject generate(ThreadContext context, IRubyObject obj) {
-        RubyString result = Generator.generateJson(context, obj, this);
+        IRubyObject result = Generator.generateJson(context, obj, this);
         RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
-        if (result.getEncoding() != UTF8Encoding.INSTANCE) {
-            if (result.isFrozen()) {
-                result = result.strDup(context.getRuntime());
-            }
-            result.force_encoding(context, info.utf8.get());
+        if (!(result instanceof RubyString)) {
+            return result;
         }
-        return result;
+
+        RubyString resultString = result.convertToString();
+        if (resultString.getEncoding() != UTF8Encoding.INSTANCE) {
+            if (resultString.isFrozen()) {
+                resultString = resultString.strDup(context.getRuntime());
+            }
+            resultString.force_encoding(context, info.utf8.get());
+        }
+
+        return resultString;
     }
 
     private static boolean matchClosingBrace(ByteList bl, int pos, int len,

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -139,8 +139,8 @@ public class GeneratorState extends RubyObject {
     }
 
     @JRubyMethod(meta=true)
-    public static IRubyObject generate(ThreadContext context, IRubyObject klass, IRubyObject obj, IRubyObject opts) {
-        return fromState(context, opts).generate(context, obj);
+    public static IRubyObject generate(ThreadContext context, IRubyObject klass, IRubyObject obj, IRubyObject opts, IRubyObject io) {
+        return fromState(context, opts)._generate(context, obj, io);
     }
 
     static GeneratorState fromState(ThreadContext context, IRubyObject opts) {
@@ -196,7 +196,7 @@ public class GeneratorState extends RubyObject {
      */
     @JRubyMethod(optional=1, visibility=Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
-        configure(context, args.length > 0 ? args[0] : null);
+        _configure(context, args.length > 0 ? args[0] : null);
         return this;
     }
 
@@ -228,9 +228,9 @@ public class GeneratorState extends RubyObject {
      * the result. If no valid JSON document can be created this method raises
      * a GeneratorError exception.
      */
-    @JRubyMethod
-    public IRubyObject generate(ThreadContext context, IRubyObject obj) {
-        IRubyObject result = Generator.generateJson(context, obj, this);
+    @JRubyMethod(visibility = Visibility.PRIVATE)
+    public IRubyObject _generate(ThreadContext context, IRubyObject obj, IRubyObject io) {
+        IRubyObject result = Generator.generateJson(context, obj, this, io);
         RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
         if (!(result instanceof RubyString)) {
             return result;
@@ -411,7 +411,7 @@ public class GeneratorState extends RubyObject {
         return strict;
     }
 
-    @JRubyMethod(name="strict")
+    @JRubyMethod(name={"strict","strict?"})
     public RubyBoolean strict_get(ThreadContext context) {
         return context.getRuntime().newBoolean(strict);
     }
@@ -484,8 +484,8 @@ public class GeneratorState extends RubyObject {
      * @param vOpts The options hash
      * @return The receiver
      */
-  @JRubyMethod(alias = "merge")
-    public IRubyObject configure(ThreadContext context, IRubyObject vOpts) {
+  @JRubyMethod(visibility=Visibility.PRIVATE)
+    public IRubyObject _configure(ThreadContext context, IRubyObject vOpts) {
         OptionsReader opts = new OptionsReader(context, vOpts);
 
         ByteList indent = opts.getString("indent");

--- a/java/src/json/ext/StringDecoder.java
+++ b/java/src/json/ext/StringDecoder.java
@@ -9,6 +9,8 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
+import java.io.IOException;
+
 /**
  * A decoder that reads a JSON-encoded string from the given sources and
  * returns its decoded form on a new ByteList. Escaped Unicode characters
@@ -29,17 +31,20 @@ final class StringDecoder extends ByteListTranscoder {
     }
 
     ByteList decode(ByteList src, int start, int end) {
-        ByteList out = new ByteList(end - start);
-        out.setEncoding(src.getEncoding());
-        init(src, start, end, out);
-        while (hasNext()) {
-            handleChar(readUtf8Char());
+        try {
+            ByteListDirectOutputStream out = new ByteListDirectOutputStream(end - start);
+            init(src, start, end, out);
+            while (hasNext()) {
+                handleChar(readUtf8Char());
+            }
+            quoteStop(pos);
+            return out.toByteListDirect(src.getEncoding());
+        } catch (IOException e) {
+            throw context.runtime.newIOErrorFromException(e);
         }
-        quoteStop(pos);
-        return out;
     }
 
-    private void handleChar(int c) {
+    private void handleChar(int c) throws IOException {
         if (c == '\\') {
             quoteStop(charStart);
             handleEscapeSequence();
@@ -48,7 +53,7 @@ final class StringDecoder extends ByteListTranscoder {
         }
     }
 
-    private void handleEscapeSequence() {
+    private void handleEscapeSequence() throws IOException {
         ensureMin(1);
         switch (readUtf8Char()) {
         case 'b':
@@ -83,7 +88,7 @@ final class StringDecoder extends ByteListTranscoder {
         }
     }
 
-    private void handleLowSurrogate(char highSurrogate) {
+    private void handleLowSurrogate(char highSurrogate) throws IOException {
         surrogatePairStart = charStart;
         ensureMin(1);
         int lowSurrogate = readUtf8Char();
@@ -103,7 +108,7 @@ final class StringDecoder extends ByteListTranscoder {
         }
     }
 
-    private void writeUtf8Char(int codePoint) {
+    private void writeUtf8Char(int codePoint) throws IOException {
         if (codePoint < 0x80) {
             append(codePoint);
         } else if (codePoint < 0x800) {

--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -9,6 +9,9 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 /**
  * An encoder that reads from the given source and outputs its representation
  * to another ByteList. The source string is fully checked for UTF-8 validity,
@@ -43,7 +46,7 @@ final class StringEncoder extends ByteListTranscoder {
         this.scriptSafe = scriptSafe;
     }
 
-    void encode(ByteList src, ByteList out) {
+    void encode(ByteList src, OutputStream out) throws IOException {
         init(src, out);
         append('"');
         while (hasNext()) {
@@ -53,7 +56,7 @@ final class StringEncoder extends ByteListTranscoder {
         append('"');
     }
 
-    private void handleChar(int c) {
+    private void handleChar(int c) throws IOException {
         switch (c) {
         case '"':
         case '\\':
@@ -97,13 +100,13 @@ final class StringEncoder extends ByteListTranscoder {
         }
     }
 
-    private void escapeChar(char c) {
+    private void escapeChar(char c) throws IOException {
         quoteStop(charStart);
         aux[ESCAPE_CHAR_OFFSET + 1] = (byte)c;
         append(aux, ESCAPE_CHAR_OFFSET, 2);
     }
 
-    private void escapeUtf8Char(int codePoint) {
+    private void escapeUtf8Char(int codePoint) throws IOException {
         int numChars = Character.toChars(codePoint, utf16, 0);
         escapeCodeUnit(utf16[0], ESCAPE_UNI1_OFFSET + 2);
         if (numChars > 1) escapeCodeUnit(utf16[1], ESCAPE_UNI2_OFFSET + 2);

--- a/json.gemspec
+++ b/json.gemspec
@@ -50,6 +50,7 @@ spec = Gem::Specification.new do |s|
 
   if java_ext
     s.platform = 'java'
+    s.files += Dir["lib/json/ext/**/*.jar"]
   else
     s.extensions = Dir["ext/json/**/extconf.rb"]
     s.files += Dir["ext/json/**/*.{c,h,rl}"]

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -1,4 +1,5 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
+
 require 'json/version'
 
 module JSON
@@ -230,8 +231,8 @@ module JSON
   #   parse(File.read(path), opts)
   #
   # See method #parse.
-  def load_file(filespec, opts = {})
-    parse(File.read(filespec), opts)
+  def load_file(filespec, opts = nil)
+    parse(File.read(filespec, encoding: Encoding::UTF_8), opts)
   end
 
   # :call-seq:
@@ -242,7 +243,7 @@ module JSON
   #
   # See method #parse!
   def load_file!(filespec, opts = {})
-    parse!(File.read(filespec), opts)
+    parse!(File.read(filespec, encoding: Encoding::UTF_8), opts)
   end
 
   # :call-seq:

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -411,6 +411,10 @@ module JSON
   #
   # Returns the Ruby objects created by parsing the given +source+.
   #
+  # BEWARE: This method is meant to serialise data from trusted user input,
+  # like from your own database server or clients under your control, it could
+  # be dangerous to allow untrusted users to pass JSON sources into it.
+  #
   # - Argument +source+ must be, or be convertible to, a \String:
   #   - If +source+ responds to instance method +to_str+,
   #     <tt>source.to_str</tt> becomes the source.
@@ -425,9 +429,6 @@ module JSON
   # - Argument +proc+, if given, must be a \Proc that accepts one argument.
   #   It will be called recursively with each result (depth-first order).
   #   See details below.
-  #   BEWARE: This method is meant to serialise data from trusted user input,
-  #   like from your own database server or clients under your control, it could
-  #   be dangerous to allow untrusted users to pass JSON sources into it.
   # - Argument +opts+, if given, contains a \Hash of options for the parsing.
   #   See {Parsing Options}[#module-JSON-label-Parsing+Options].
   #   The default options can be changed via method JSON.unsafe_load_default_options=.
@@ -564,6 +565,16 @@ module JSON
   #
   # Returns the Ruby objects created by parsing the given +source+.
   #
+  # BEWARE: This method is meant to serialise data from trusted user input,
+  # like from your own database server or clients under your control, it could
+  # be dangerous to allow untrusted users to pass JSON sources into it.
+  # If you must use it, use JSON.unsafe_load instead to make it clear.
+  #
+  # Since JSON version 2.8.0, `load` emits a deprecation warning when a
+  # non native type is deserialized, without `create_additions` being explicitly
+  # enabled, and in JSON version 3.0, `load` will have `create_additions` disabled
+  # by default.
+  #
   # - Argument +source+ must be, or be convertible to, a \String:
   #   - If +source+ responds to instance method +to_str+,
   #     <tt>source.to_str</tt> becomes the source.
@@ -578,10 +589,6 @@ module JSON
   # - Argument +proc+, if given, must be a \Proc that accepts one argument.
   #   It will be called recursively with each result (depth-first order).
   #   See details below.
-  #   BEWARE: This method is meant to serialise data from trusted user input,
-  #   like from your own database server or clients under your control, it could
-  #   be dangerous to allow untrusted users to pass JSON sources into it.
-  #   If you must use it, use JSON.unsafe_load instead to make it clear.
   # - Argument +opts+, if given, contains a \Hash of options for the parsing.
   #   See {Parsing Options}[#module-JSON-label-Parsing+Options].
   #   The default options can be changed via method JSON.load_default_options=.

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -26,7 +26,7 @@ module JSON
       elsif object.respond_to?(:to_str)
         str = object.to_str
         if str.is_a?(String)
-          return JSON.parse(object.to_str, opts)
+          return JSON.parse(str, opts)
         end
       end
 

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -285,7 +285,7 @@ module JSON
     if State === opts
       opts.generate(obj)
     else
-      State.generate(obj, opts)
+      State.generate(obj, opts, nil)
     end
   end
 
@@ -793,17 +793,14 @@ module JSON
     opts = opts.merge(:max_nesting => limit) if limit
     opts = merge_dump_options(opts, **kwargs) if kwargs
 
-    result = begin
-      generate(obj, opts)
+    begin
+      if State === opts
+        opts.generate(obj, anIO)
+      else
+        State.generate(obj, opts, anIO)
+      end
     rescue JSON::NestingError
       raise ArgumentError, "exceed depth limit"
-    end
-
-    if anIO.nil?
-      result
-    else
-      anIO.write result
-      anIO
     end
   end
 

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -47,6 +47,17 @@ module JSON
 
         alias_method :merge, :configure
 
+        # call-seq:
+        #   generate(obj) -> String
+        #   generate(obj, anIO) -> anIO
+        #
+        # Generates a valid JSON document from object +obj+ and returns the
+        # result. If no valid JSON document can be created this method raises a
+        # GeneratorError exception.
+        def generate(obj, io = nil)
+          _generate(obj, io)
+        end
+
         # call-seq: to_h
         #
         # Returns the configuration instance variables as a hash, that can be

--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JSON
-  VERSION = '2.8.0'
+  VERSION = '2.8.1'
 end

--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JSON
-  VERSION = '2.8.0.alpha1'
+  VERSION = '2.8.0'
 end

--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JSON
-  VERSION = '2.8.1'
+  VERSION = '2.8.2'
 end

--- a/test/json/json_addition_test.rb
+++ b/test/json/json_addition_test.rb
@@ -163,7 +163,7 @@ class JSONAdditionTest < Test::Unit::TestCase
   end
 
   def test_deprecated_load_create_additions
-    assert_warning(/use JSON\.unsafe_load/) do
+    assert_deprecated_warning(/use JSON\.unsafe_load/) do
       JSON.load(JSON.dump(Time.now))
     end
   end

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -209,7 +209,6 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     Encoding.default_external = encoding
     yield
   ensure
-    verbose = $VERBOSE
     Encoding.default_external = previous_encoding
     $VERBOSE = verbose
   end

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'test_helper'
 require 'stringio'
 require 'tempfile'
@@ -189,7 +190,29 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     test_load_file_with_option_shared(:load_file!)
   end
 
+  def test_load_file_with_bad_default_external_encoding
+    data = { "key" => "€" }
+    temp_file_containing(JSON.dump(data)) do |path|
+      loaded_data = with_external_encoding(Encoding::US_ASCII) do
+        JSON.load_file(path)
+      end
+      assert_equal data, loaded_data
+    end
+  end
+
   private
+
+  def with_external_encoding(encoding)
+    verbose = $VERBOSE
+    $VERBOSE = nil
+    previous_encoding = Encoding.default_external
+    Encoding.default_external = encoding
+    yield
+  ensure
+    verbose = $VERBOSE
+    Encoding.default_external = previous_encoding
+    $VERBOSE = verbose
+  end
 
   def test_load_shared(method_name)
     temp_file_containing(@json) do |filespec|


### PR DESCRIPTION
Note, this PR is a proof-of-concept of direct IO dumping in the json library. It works, but is not as fast as it could be, and there's no CRuby implementation yet.

Json.dump allows you to pass an IO to which the dump output will be sent, but it still buffers the entire output in memory before sending it to the given IO. This leads to issues on JRuby like jruby/jruby#6265 when it tries to create a byte[] that exceeds the maximum size of a signed int (JVM's array size limit).

This commit plumbs the IO all the way through the generation logic so that it can be written to directly without filling a temporary memory buffer first. This allow JRuby to dump object graphs that would normally produce more content than the JVM can hold in a single array, providing a workaround for jruby/jruby#6265.

It is unfortunately a bit slow to dump directly to IO due to the many small writes that all acquire locks and participate in the IO encoding subsystem. A more direct path that can skip some of these pieces could be more competitive with the in-memory version, but functionally it expands the size of graphs that cana be dumped when using JRuby.

See flori/json#524