### PR TITLE
Make `JSON.generate` 1.75x as fast

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -59,14 +59,15 @@ typedef struct FBufferStruct {
 
 static FBuffer *fbuffer_alloc(unsigned long initial_length);
 static void fbuffer_free(FBuffer *fb);
+#ifndef JSON_GENERATOR
 static void fbuffer_clear(FBuffer *fb);
+#endif
 static void fbuffer_append(FBuffer *fb, const char *newstr, unsigned long len);
 #ifdef JSON_GENERATOR
 static void fbuffer_append_long(FBuffer *fb, long number);
 #endif
 static void fbuffer_append_char(FBuffer *fb, char newchr);
 #ifdef JSON_GENERATOR
-static FBuffer *fbuffer_dup(FBuffer *fb);
 static VALUE fbuffer_to_s(FBuffer *fb);
 #endif
 
@@ -86,10 +87,12 @@ static void fbuffer_free(FBuffer *fb)
     ruby_xfree(fb);
 }
 
+#ifndef JSON_GENERATOR
 static void fbuffer_clear(FBuffer *fb)
 {
     fb->len = 0;
 }
+#endif
 
 static void fbuffer_inc_capa(FBuffer *fb, unsigned long requested)
 {
@@ -164,16 +167,6 @@ static void fbuffer_append_long(FBuffer *fb, long number)
     char buf[20];
     unsigned long len = fltoa(number, buf);
     fbuffer_append(fb, buf, len);
-}
-
-static FBuffer *fbuffer_dup(FBuffer *fb)
-{
-    unsigned long len = fb->len;
-    FBuffer *result;
-
-    result = fbuffer_alloc(len);
-    fbuffer_append(result, FBUFFER_PAIR(fb));
-    return result;
 }
 
 static VALUE fbuffer_to_s(FBuffer *fb)

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -610,7 +610,6 @@ static void State_free(void *ptr)
     if (state->space_before) ruby_xfree(state->space_before);
     if (state->object_nl) ruby_xfree(state->object_nl);
     if (state->array_nl) ruby_xfree(state->array_nl);
-    if (state->array_delim) fbuffer_free(state->array_delim);
     if (state->object_delim) fbuffer_free(state->object_delim);
     if (state->object_delim2) fbuffer_free(state->object_delim2);
     ruby_xfree(state);
@@ -625,7 +624,6 @@ static size_t State_memsize(const void *ptr)
     if (state->space_before) size += state->space_before_len + 1;
     if (state->object_nl) size += state->object_nl_len + 1;
     if (state->array_nl) size += state->array_nl_len + 1;
-    if (state->array_delim) size += FBUFFER_CAPA(state->array_delim);
     if (state->object_delim) size += FBUFFER_CAPA(state->object_delim);
     if (state->object_delim2) size += FBUFFER_CAPA(state->object_delim2);
     return size;
@@ -922,8 +920,6 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     char *indent = state->indent;
     long indent_len = state->indent_len;
     long max_nesting = state->max_nesting;
-    char *delim = FBUFFER_PTR(state->array_delim);
-    long delim_len = FBUFFER_LEN(state->array_delim);
     long depth = ++state->depth;
     int i, j;
     if (max_nesting != 0 && depth > max_nesting) {
@@ -933,7 +929,10 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     fbuffer_append_char(buffer, '[');
     if (array_nl) fbuffer_append(buffer, array_nl, array_nl_len);
     for(i = 0; i < RARRAY_LEN(obj); i++) {
-        if (i > 0) fbuffer_append(buffer, delim, delim_len);
+        if (i > 0) {
+            fbuffer_append_char(buffer, ',');
+            if (RB_UNLIKELY(state->array_nl)) fbuffer_append(buffer, state->array_nl, state->array_nl_len);
+        }
         if (indent) {
             for (j = 0; j < depth; j++) {
                 fbuffer_append(buffer, indent, indent_len);
@@ -1086,13 +1085,6 @@ static FBuffer *cState_prepare_buffer(VALUE self)
     fbuffer_append_char(state->object_delim2, ':');
     if (state->space) fbuffer_append(state->object_delim2, state->space, state->space_len);
 
-    if (state->array_delim) {
-        fbuffer_clear(state->array_delim);
-    } else {
-        state->array_delim = fbuffer_alloc(16);
-    }
-    fbuffer_append_char(state->array_delim, ',');
-    if (state->array_nl) fbuffer_append(state->array_delim, state->array_nl, state->array_nl_len);
     return buffer;
 }
 
@@ -1171,7 +1163,6 @@ static VALUE cState_init_copy(VALUE obj, VALUE orig)
     objState->space_before = fstrndup(origState->space_before, origState->space_before_len);
     objState->object_nl = fstrndup(origState->object_nl, origState->object_nl_len);
     objState->array_nl = fstrndup(origState->array_nl, origState->array_nl_len);
-    if (origState->array_delim) objState->array_delim = fbuffer_dup(origState->array_delim);
     if (origState->object_delim) objState->object_delim = fbuffer_dup(origState->object_delim);
     if (origState->object_delim2) objState->object_delim2 = fbuffer_dup(origState->object_delim2);
     return obj;

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -610,7 +610,6 @@ static void State_free(void *ptr)
     if (state->space_before) ruby_xfree(state->space_before);
     if (state->object_nl) ruby_xfree(state->object_nl);
     if (state->array_nl) ruby_xfree(state->array_nl);
-    if (state->object_delim2) fbuffer_free(state->object_delim2);
     ruby_xfree(state);
 }
 
@@ -623,7 +622,6 @@ static size_t State_memsize(const void *ptr)
     if (state->space_before) size += state->space_before_len + 1;
     if (state->object_nl) size += state->object_nl_len + 1;
     if (state->array_nl) size += state->array_nl_len + 1;
-    if (state->object_delim2) size += FBUFFER_CAPA(state->object_delim2);
     return size;
 }
 
@@ -841,8 +839,6 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     long object_nl_len = state->object_nl_len;
     char *indent = state->indent;
     long indent_len = state->indent_len;
-    char *delim2 = FBUFFER_PTR(state->object_delim2);
-    long delim2_len = FBUFFER_LEN(state->object_delim2);
     long depth = state->depth;
     int j;
     VALUE klass, key_to_s;
@@ -867,7 +863,9 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     }
     Check_Type(key_to_s, T_STRING);
     generate_json(buffer, Vstate, state, key_to_s);
-    fbuffer_append(buffer, delim2, delim2_len);
+    if (RB_UNLIKELY(state->space_before)) fbuffer_append(buffer, state->space_before, state->space_before_len);
+    fbuffer_append_char(buffer, ':');
+    if (RB_UNLIKELY(state->space)) fbuffer_append(buffer, state->space, state->space_len);
     generate_json(buffer, Vstate, state, val);
 
     arg->iter++;
@@ -1066,15 +1064,6 @@ static FBuffer *cState_prepare_buffer(VALUE self)
     GET_STATE(self);
     buffer = fbuffer_alloc(state->buffer_initial_length);
 
-    if (state->object_delim2) {
-        fbuffer_clear(state->object_delim2);
-    } else {
-        state->object_delim2 = fbuffer_alloc(16);
-    }
-    if (state->space_before) fbuffer_append(state->object_delim2, state->space_before, state->space_before_len);
-    fbuffer_append_char(state->object_delim2, ':');
-    if (state->space) fbuffer_append(state->object_delim2, state->space, state->space_len);
-
     return buffer;
 }
 
@@ -1153,7 +1142,6 @@ static VALUE cState_init_copy(VALUE obj, VALUE orig)
     objState->space_before = fstrndup(origState->space_before, origState->space_before_len);
     objState->object_nl = fstrndup(origState->object_nl, origState->object_nl_len);
     objState->array_nl = fstrndup(origState->array_nl, origState->array_nl_len);
-    if (origState->object_delim2) objState->object_delim2 = fbuffer_dup(origState->object_delim2);
     return obj;
 }
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1035,35 +1035,56 @@ static void generate_json_float(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
 static void generate_json(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
     VALUE tmp;
-    VALUE klass = CLASS_OF(obj);
-    if (klass == rb_cHash) {
-        generate_json_object(buffer, Vstate, state, obj);
-    } else if (klass == rb_cArray) {
-        generate_json_array(buffer, Vstate, state, obj);
-    } else if (klass == rb_cString) {
-        generate_json_string(buffer, Vstate, state, obj);
-    } else if (obj == Qnil) {
+    if (obj == Qnil) {
         generate_json_null(buffer, Vstate, state, obj);
     } else if (obj == Qfalse) {
         generate_json_false(buffer, Vstate, state, obj);
     } else if (obj == Qtrue) {
         generate_json_true(buffer, Vstate, state, obj);
-    } else if (FIXNUM_P(obj)) {
-        generate_json_fixnum(buffer, Vstate, state, obj);
-    } else if (RB_TYPE_P(obj, T_BIGNUM)) {
-        generate_json_bignum(buffer, Vstate, state, obj);
-    } else if (klass == rb_cFloat) {
-        generate_json_float(buffer, Vstate, state, obj);
-    } else if (state->strict) {
-        rb_raise(eGeneratorError, "%"PRIsVALUE" not allowed in JSON", RB_OBJ_STRING(CLASS_OF(obj)));
-    } else if (rb_respond_to(obj, i_to_json)) {
-        tmp = rb_funcall(obj, i_to_json, 1, Vstate);
-        Check_Type(tmp, T_STRING);
-        fbuffer_append_str(buffer, tmp);
+    } else if (RB_SPECIAL_CONST_P(obj)) {
+        if (RB_FIXNUM_P(obj)) {
+            generate_json_fixnum(buffer, Vstate, state, obj);
+        } else if (RB_FLONUM_P(obj)) {
+            generate_json_float(buffer, Vstate, state, obj);
+        } else {
+            goto general;
+        }
     } else {
-        tmp = rb_funcall(obj, i_to_s, 0);
-        Check_Type(tmp, T_STRING);
-        generate_json_string(buffer, Vstate, state, tmp);
+        VALUE klass = RBASIC_CLASS(obj);
+        switch (RB_BUILTIN_TYPE(obj)) {
+            case T_BIGNUM:
+                generate_json_bignum(buffer, Vstate, state, obj);
+                break;
+            case T_HASH:
+                if (klass != rb_cHash) goto general;
+                generate_json_object(buffer, Vstate, state, obj);
+                break;
+            case T_ARRAY:
+                if (klass != rb_cArray) goto general;
+                generate_json_array(buffer, Vstate, state, obj);
+                break;
+            case T_STRING:
+                if (klass != rb_cString) goto general;
+                generate_json_string(buffer, Vstate, state, obj);
+                break;
+            case T_FLOAT:
+                if (klass != rb_cFloat) goto general;
+                generate_json_float(buffer, Vstate, state, obj);
+                break;
+            default:
+            general:
+                if (state->strict) {
+                    rb_raise(eGeneratorError, "%"PRIsVALUE" not allowed in JSON", RB_OBJ_STRING(CLASS_OF(obj)));
+                } else if (rb_respond_to(obj, i_to_json)) {
+                    tmp = rb_funcall(obj, i_to_json, 1, Vstate);
+                    Check_Type(tmp, T_STRING);
+                    fbuffer_append_str(buffer, tmp);
+                } else {
+                    tmp = rb_funcall(obj, i_to_s, 0);
+                    Check_Type(tmp, T_STRING);
+                    generate_json_string(buffer, Vstate, state, tmp);
+                }
+        }
     }
 }
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -939,7 +939,7 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
                 fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
-        generate_json(buffer, Vstate, state, rb_ary_entry(obj, i));
+        generate_json(buffer, Vstate, state, RARRAY_AREF(obj, i));
     }
     state->depth = --depth;
     if (RB_UNLIKELY(state->array_nl)) {

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -877,7 +877,7 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
         key_to_s = rb_funcall(key, i_to_s, 0);
     }
     Check_Type(key_to_s, T_STRING);
-    generate_json(buffer, Vstate, state, key_to_s);
+    generate_json_string(buffer, Vstate, state, key_to_s);
     if (RB_UNLIKELY(state->space_before)) fbuffer_append(buffer, state->space_before, state->space_before_len);
     fbuffer_append_char(buffer, ':');
     if (RB_UNLIKELY(state->space)) fbuffer_append(buffer, state->space, state->space_len);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -18,6 +18,10 @@ static ID i_to_s, i_to_json, i_new, i_indent, i_space, i_space_before,
           i_aref, i_send, i_respond_to_p, i_match, i_keys, i_depth,
           i_buffer_initial_length, i_dup, i_script_safe, i_escape_slash, i_strict;
 
+#ifndef RB_UNLIKELY
+#define RB_UNLIKELY(cond) (cond)
+#endif
+
 /*
  * Copyright 2001-2004 Unicode, Inc.
  *

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -835,21 +835,17 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     JSON_Generator_State *state = arg->state;
     VALUE Vstate = arg->Vstate;
 
-    char *object_nl = state->object_nl;
-    long object_nl_len = state->object_nl_len;
-    char *indent = state->indent;
-    long indent_len = state->indent_len;
     long depth = state->depth;
     int j;
     VALUE klass, key_to_s;
 
     if (arg->iter > 0) fbuffer_append_char(buffer, ',');
-    if (object_nl) {
-        fbuffer_append(buffer, object_nl, object_nl_len);
+    if (RB_UNLIKELY(state->object_nl)) {
+        fbuffer_append(buffer, state->object_nl, state->object_nl_len);
     }
-    if (indent) {
+    if (RB_UNLIKELY(state->indent)) {
         for (j = 0; j < depth; j++) {
-            fbuffer_append(buffer, indent, indent_len);
+            fbuffer_append(buffer, state->indent, state->indent_len);
         }
     }
 
@@ -874,10 +870,6 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
 
 static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
-    char *object_nl = state->object_nl;
-    long object_nl_len = state->object_nl_len;
-    char *indent = state->indent;
-    long indent_len = state->indent_len;
     long max_nesting = state->max_nesting;
     long depth = ++state->depth;
     int j;
@@ -896,11 +888,11 @@ static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
     rb_hash_foreach(obj, json_object_i, (VALUE)&arg);
 
     depth = --state->depth;
-    if (object_nl) {
-        fbuffer_append(buffer, object_nl, object_nl_len);
-        if (indent) {
+    if (RB_UNLIKELY(state->object_nl)) {
+        fbuffer_append(buffer, state->object_nl, state->object_nl_len);
+        if (RB_UNLIKELY(state->indent)) {
             for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
+                fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
     }
@@ -909,10 +901,6 @@ static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
 
 static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
-    char *array_nl = state->array_nl;
-    long array_nl_len = state->array_nl_len;
-    char *indent = state->indent;
-    long indent_len = state->indent_len;
     long max_nesting = state->max_nesting;
     long depth = ++state->depth;
     int i, j;
@@ -921,25 +909,25 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
         rb_raise(eNestingError, "nesting of %ld is too deep", --state->depth);
     }
     fbuffer_append_char(buffer, '[');
-    if (array_nl) fbuffer_append(buffer, array_nl, array_nl_len);
+    if (RB_UNLIKELY(state->array_nl)) fbuffer_append(buffer, state->array_nl, state->array_nl_len);
     for(i = 0; i < RARRAY_LEN(obj); i++) {
         if (i > 0) {
             fbuffer_append_char(buffer, ',');
             if (RB_UNLIKELY(state->array_nl)) fbuffer_append(buffer, state->array_nl, state->array_nl_len);
         }
-        if (indent) {
+        if (RB_UNLIKELY(state->indent)) {
             for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
+                fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
         generate_json(buffer, Vstate, state, rb_ary_entry(obj, i));
     }
     state->depth = --depth;
-    if (array_nl) {
-        fbuffer_append(buffer, array_nl, array_nl_len);
-        if (indent) {
+    if (RB_UNLIKELY(state->array_nl)) {
+        fbuffer_append(buffer, state->array_nl, state->array_nl_len);
+        if (RB_UNLIKELY(state->indent)) {
             for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
+                fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
     }

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -934,11 +934,13 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     fbuffer_append_char(buffer, ']');
 }
 
+static int usascii_encindex, utf8_encindex;
+
 #ifdef HAVE_RUBY_ENCODING_H
-static int enc_utf8_compatible_p(rb_encoding *enc)
+static int enc_utf8_compatible_p(int enc_idx)
 {
-    if (enc == rb_usascii_encoding()) return 1;
-    if (enc == rb_utf8_encoding()) return 1;
+    if (enc_idx == usascii_encindex) return 1;
+    if (enc_idx == utf8_encindex) return 1;
     return 0;
 }
 #endif
@@ -947,7 +949,7 @@ static void generate_json_string(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
 {
     fbuffer_append_char(buffer, '"');
 #ifdef HAVE_RUBY_ENCODING_H
-    if (!enc_utf8_compatible_p(rb_enc_get(obj))) {
+    if (!enc_utf8_compatible_p(RB_ENCODING_GET(obj))) {
         obj = rb_str_export_to_enc(obj, rb_utf8_encoding());
     }
 #endif
@@ -1626,4 +1628,7 @@ void Init_generator(void)
     i_match = rb_intern("match");
     i_keys = rb_intern("keys");
     i_dup = rb_intern("dup");
+
+    usascii_encindex = rb_usascii_encindex();
+    utf8_encindex = rb_utf8_encindex();
 }

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -610,7 +610,6 @@ static void State_free(void *ptr)
     if (state->space_before) ruby_xfree(state->space_before);
     if (state->object_nl) ruby_xfree(state->object_nl);
     if (state->array_nl) ruby_xfree(state->array_nl);
-    if (state->object_delim) fbuffer_free(state->object_delim);
     if (state->object_delim2) fbuffer_free(state->object_delim2);
     ruby_xfree(state);
 }
@@ -624,7 +623,6 @@ static size_t State_memsize(const void *ptr)
     if (state->space_before) size += state->space_before_len + 1;
     if (state->object_nl) size += state->object_nl_len + 1;
     if (state->array_nl) size += state->array_nl_len + 1;
-    if (state->object_delim) size += FBUFFER_CAPA(state->object_delim);
     if (state->object_delim2) size += FBUFFER_CAPA(state->object_delim2);
     return size;
 }
@@ -843,15 +841,13 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     long object_nl_len = state->object_nl_len;
     char *indent = state->indent;
     long indent_len = state->indent_len;
-    char *delim = FBUFFER_PTR(state->object_delim);
-    long delim_len = FBUFFER_LEN(state->object_delim);
     char *delim2 = FBUFFER_PTR(state->object_delim2);
     long delim2_len = FBUFFER_LEN(state->object_delim2);
     long depth = state->depth;
     int j;
     VALUE klass, key_to_s;
 
-    if (arg->iter > 0) fbuffer_append(buffer, delim, delim_len);
+    if (arg->iter > 0) fbuffer_append_char(buffer, ',');
     if (object_nl) {
         fbuffer_append(buffer, object_nl, object_nl_len);
     }
@@ -1070,12 +1066,6 @@ static FBuffer *cState_prepare_buffer(VALUE self)
     GET_STATE(self);
     buffer = fbuffer_alloc(state->buffer_initial_length);
 
-    if (state->object_delim) {
-        fbuffer_clear(state->object_delim);
-    } else {
-        state->object_delim = fbuffer_alloc(16);
-    }
-    fbuffer_append_char(state->object_delim, ',');
     if (state->object_delim2) {
         fbuffer_clear(state->object_delim2);
     } else {
@@ -1163,7 +1153,6 @@ static VALUE cState_init_copy(VALUE obj, VALUE orig)
     objState->space_before = fstrndup(origState->space_before, origState->space_before_len);
     objState->object_nl = fstrndup(origState->object_nl, origState->object_nl_len);
     objState->array_nl = fstrndup(origState->array_nl, origState->array_nl_len);
-    if (origState->object_delim) objState->object_delim = fbuffer_dup(origState->object_delim);
     if (origState->object_delim2) objState->object_delim2 = fbuffer_dup(origState->object_delim2);
     return obj;
 }

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -66,7 +66,6 @@ typedef struct JSON_Generator_StateStruct {
     long object_nl_len;
     char *array_nl;
     long array_nl_len;
-    FBuffer *object_delim;
     FBuffer *object_delim2;
     long max_nesting;
     char allow_nan;

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -66,7 +66,6 @@ typedef struct JSON_Generator_StateStruct {
     long object_nl_len;
     char *array_nl;
     long array_nl_len;
-    FBuffer *array_delim;
     FBuffer *object_delim;
     FBuffer *object_delim2;
     long max_nesting;

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -66,7 +66,6 @@ typedef struct JSON_Generator_StateStruct {
     long object_nl_len;
     char *array_nl;
     long array_nl_len;
-    FBuffer *object_delim2;
     long max_nesting;
     char allow_nan;
     char ascii_only;


### PR DESCRIPTION
This PR speeds up `JSON.generate` by approximately 1.75x (485k instructions per second -> 840k instructions per second) for [the benchmark of Oj](https://www.ohler.com/dev/oj_misc/performance_compat.html). This makes `JSON.generate` nearly as fast as `Oj.dump`.

Before:

```
$ ruby --yjit -Ilib -I ext oj-bench.rb
** Oj version 3.16.3 **
ruby 3.4.0dev (2023-12-27T05:30:20Z master 862cfcaf75) +YJIT [x86_64-linux]
Warming up --------------------------------------
             Oj.dump    83.089k i/100ms
    Oj.dump [compat]    72.410k i/100ms
     Oj.dump [rails]    57.698k i/100ms
       JSON.generate    49.706k i/100ms
Calculating -------------------------------------
             Oj.dump    836.635k (± 0.4%) i/s -     12.630M in  15.095866s
    Oj.dump [compat]    718.031k (± 0.2%) i/s -     10.789M in  15.026031s
     Oj.dump [rails]    573.882k (± 0.3%) i/s -      8.655M in  15.081085s
       JSON.generate    484.650k (± 1.0%) i/s -      7.307M in  15.078021s
```

After:

```
$ ruby --yjit -Ilib -I ext oj-bench.rb
** Oj version 3.16.3 **
ruby 3.4.0dev (2023-12-27T05:30:20Z master 862cfcaf75) +YJIT [x86_64-linux]
Warming up --------------------------------------
             Oj.dump    83.349k i/100ms
    Oj.dump [compat]    71.605k i/100ms
     Oj.dump [rails]    57.058k i/100ms
       JSON.generate    84.498k i/100ms
Calculating -------------------------------------
             Oj.dump    837.304k (± 0.3%) i/s -     12.586M in  15.031372s
    Oj.dump [compat]    718.657k (± 0.5%) i/s -     10.812M in  15.045573s
     Oj.dump [rails]    565.824k (± 0.3%) i/s -      8.502M in  15.025348s
       JSON.generate    839.614k (± 0.3%) i/s -     12.675M in  15.096044s
```

This PR consists of the following several improvements.

* Drop prebuild of `array_delim`, etc.
  * `array_delim` is usually a single comma character. Using `memcpy` to copy a single character was inefficient.
  * It is much faster to output a comma and (optional) `array_nl` separately without prebuild.
  * This improved the speed by about 24%, from 480k i/s to 593k i/s.

* Use faster Ruby API for encoding checks.
  * This improved the speed by 12%, from 593k i/s to 665k i/s.

* Use a fast path when string escaping is not needed.
  * This improves the performance by 16%, from 665ki/s to 770k i/s.

* Use faster Ruby API for dispatching the class of objects.
  * This improved performance by 5%, from 770k i/s to 806k i/s.

* Use `generate_json_string` for object keys.
  * Since object keys are already verified to be String, using `generate_json` in general dispatch was an unnecessary overhead.
  * This improved the performance by 3%, from 806k i/s to 830k i/s.

* Use faster Ruby API for reading array elements.
  * This improved the performance by about 4%, from 830k i/s to 854k i/s.

I made them into one PR because I thought separating this to multiple PRs would bring many conflicts between PRs. However, if you want me to do so, feel free to let me know.