### PR TITLE
[FIX] JSON.dump for hash with duplicate key

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -623,7 +623,8 @@ module JSON
     opts = JSON.dump_default_options
     opts = opts.merge(:max_nesting => limit) if limit
     opts = merge_dump_options(opts, **kwargs) if kwargs
-    result = generate(obj, opts)
+    sanitized_obj = make_json_compatible(obj)
+    result = generate(sanitized_obj, opts)
     if anIO
       anIO.write result
       anIO
@@ -644,8 +645,24 @@ module JSON
     opts
   end
 
+  def make_json_compatible(obj)
+    case obj
+    when Hash
+      result = {}
+      obj.each do |k, v|
+        k = k.to_s unless String === k
+        result[k] = make_json_compatible(v)
+      end
+      result
+    when Array
+      obj.map { |v| make_json_compatible(v) }
+    else
+      obj
+    end
+  end
+
   class << self
-    private :merge_dump_options
+    private :merge_dump_options, :make_json_compatible
   end
 end
 

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -69,6 +69,10 @@ EOT
     assert_equal '{}', dump({}, strict: true)
   end
 
+  def test_dump_duplicate_key_hash
+    assert_equal "{\"a\":5,\"c\":{\"b\":6}}", dump({ 'a' => 1,  a: 5, c: { 'b' => 2, b: 6 } })
+  end
+
   def test_generate_pretty
     json = pretty_generate({})
     assert_equal(<<'EOT'.chomp, json)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because to fix #563 

The output for the hash is inconsistent when using `JSON.dump` with the duplicate key. Specifically, if we examine the result below, the key 'a' appears twice in the output JSON for the same key 'a'.

For example:

```ruby
JSON.dump({ 'a' => 1, :a => 2 })
```

### Actual Result:

```json
"{\"a\":1,\"a\":2}"
```

### Expected result:

```json
"{\"a\":2}"
```

cc: @byroot @hsbt 
