### PR TITLE
JSONPure: String#to_json should raise on invalid encoding

### DIFF
--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -450,6 +450,9 @@ module JSON
           def to_json(state = nil, *args)
             state = State.from_state(state)
             if encoding == ::Encoding::UTF_8
+              unless valid_encoding?
+                raise GeneratorError, "source sequence is illegal/malformed utf-8"
+              end
               string = self
             else
               string = encode(::Encoding::UTF_8)

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -438,6 +438,13 @@ EOT
     end
   end
 
+  def test_invalid_encoding_string
+    error = assert_raise(JSON::GeneratorError) do
+      "\x82\xAC\xEF".to_json
+    end
+    assert_includes error.message, "source sequence is illegal/malformed utf-8"
+  end
+
   if defined?(JSON::Ext::Generator) and RUBY_PLATFORM != "java"
     def test_string_ext_included_calls_super
       included = false


### PR DESCRIPTION
Fix: #344

This matches the ext behavior.