### PR TITLE
Various `JSON.generate` optimizations

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -55,14 +55,15 @@ typedef struct FBufferStruct {
 
 static FBuffer *fbuffer_alloc(unsigned long initial_length);
 static void fbuffer_free(FBuffer *fb);
+#ifndef JSON_GENERATOR
 static void fbuffer_clear(FBuffer *fb);
+#endif
 static void fbuffer_append(FBuffer *fb, const char *newstr, unsigned long len);
 #ifdef JSON_GENERATOR
 static void fbuffer_append_long(FBuffer *fb, long number);
 #endif
 static void fbuffer_append_char(FBuffer *fb, char newchr);
 #ifdef JSON_GENERATOR
-static FBuffer *fbuffer_dup(FBuffer *fb);
 static VALUE fbuffer_to_s(FBuffer *fb);
 #endif
 
@@ -86,10 +87,12 @@ static void fbuffer_free(FBuffer *fb)
     ruby_xfree(fb);
 }
 
+#ifndef JSON_GENERATOR
 static void fbuffer_clear(FBuffer *fb)
 {
     fb->len = 0;
 }
+#endif
 
 static inline void fbuffer_inc_capa(FBuffer *fb, unsigned long requested)
 {
@@ -166,16 +169,6 @@ static void fbuffer_append_long(FBuffer *fb, long number)
     char buf[20];
     unsigned long len = fltoa(number, buf);
     fbuffer_append(fb, buf, len);
-}
-
-static FBuffer *fbuffer_dup(FBuffer *fb)
-{
-    unsigned long len = fb->len;
-    FBuffer *result;
-
-    result = fbuffer_alloc(len);
-    fbuffer_append(result, FBUFFER_PAIR(fb));
-    return result;
 }
 
 static VALUE fbuffer_to_s(FBuffer *fb)

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1,6 +1,10 @@
 #include "../fbuffer/fbuffer.h"
 #include "generator.h"
 
+#ifndef RB_UNLIKELY
+#define RB_UNLIKELY(cond) (cond)
+#endif
+
 static VALUE mJSON, mExt, mGenerator, cState, mGeneratorMethods, mObject,
              mHash, mArray,
 #ifdef RUBY_INTEGER_UNIFICATION
@@ -678,7 +682,7 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
             break;
     }
 
-    generate_json(buffer, Vstate, state, key_to_s);
+    generate_json_string(buffer, Vstate, state, key_to_s);
     fbuffer_append(buffer, delim2, delim2_len);
     generate_json(buffer, Vstate, state, val);
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -743,7 +743,7 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
                 fbuffer_append(buffer, indent, indent_len);
             }
         }
-        generate_json(buffer, Vstate, state, rb_ary_entry(obj, i));
+        generate_json(buffer, Vstate, state, RARRAY_AREF(obj, i));
     }
     state->depth = --depth;
     if (array_nl) {

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -642,20 +642,16 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     JSON_Generator_State *state = arg->state;
     VALUE Vstate = arg->Vstate;
 
-    char *object_nl = state->object_nl;
-    long object_nl_len = state->object_nl_len;
-    char *indent = state->indent;
-    long indent_len = state->indent_len;
     long depth = state->depth;
     int j;
 
     if (arg->iter > 0) fbuffer_append_char(buffer, ',');
-    if (object_nl) {
-        fbuffer_append(buffer, object_nl, object_nl_len);
+    if (RB_UNLIKELY(state->object_nl)) {
+        fbuffer_append(buffer, state->object_nl, state->object_nl_len);
     }
-    if (indent) {
+    if (RB_UNLIKELY(state->indent)) {
         for (j = 0; j < depth; j++) {
-            fbuffer_append(buffer, indent, indent_len);
+            fbuffer_append(buffer, state->indent, state->indent_len);
         }
     }
 
@@ -684,10 +680,6 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
 
 static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
-    char *object_nl = state->object_nl;
-    long object_nl_len = state->object_nl_len;
-    char *indent = state->indent;
-    long indent_len = state->indent_len;
     long max_nesting = state->max_nesting;
     long depth = ++state->depth;
     int j;
@@ -705,11 +697,11 @@ static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
     rb_hash_foreach(obj, json_object_i, (VALUE)&arg);
 
     depth = --state->depth;
-    if (object_nl) {
-        fbuffer_append(buffer, object_nl, object_nl_len);
-        if (indent) {
+    if (RB_UNLIKELY(state->object_nl)) {
+        fbuffer_append(buffer, state->object_nl, state->object_nl_len);
+        if (RB_UNLIKELY(state->indent)) {
             for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
+                fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
     }
@@ -718,10 +710,6 @@ static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
 
 static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
-    char *array_nl = state->array_nl;
-    long array_nl_len = state->array_nl_len;
-    char *indent = state->indent;
-    long indent_len = state->indent_len;
     long max_nesting = state->max_nesting;
     long depth = ++state->depth;
     int i, j;
@@ -729,25 +717,25 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
         rb_raise(eNestingError, "nesting of %ld is too deep", --state->depth);
     }
     fbuffer_append_char(buffer, '[');
-    if (array_nl) fbuffer_append(buffer, array_nl, array_nl_len);
+    if (RB_UNLIKELY(state->array_nl)) fbuffer_append(buffer, state->array_nl, state->array_nl_len);
     for(i = 0; i < RARRAY_LEN(obj); i++) {
         if (i > 0) {
             fbuffer_append_char(buffer, ',');
             if (RB_UNLIKELY(state->array_nl)) fbuffer_append(buffer, state->array_nl, state->array_nl_len);
         }
-        if (indent) {
+        if (RB_UNLIKELY(state->indent)) {
             for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
+                fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
         generate_json(buffer, Vstate, state, RARRAY_AREF(obj, i));
     }
     state->depth = --depth;
-    if (array_nl) {
-        fbuffer_append(buffer, array_nl, array_nl_len);
-        if (indent) {
+    if (RB_UNLIKELY(state->array_nl)) {
+        fbuffer_append(buffer, state->array_nl, state->array_nl_len);
+        if (RB_UNLIKELY(state->indent)) {
             for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
+                fbuffer_append(buffer, state->indent, state->indent_len);
             }
         }
     }

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -742,17 +742,19 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     fbuffer_append_char(buffer, ']');
 }
 
-static int enc_utf8_compatible_p(rb_encoding *enc)
+static int usascii_encindex, utf8_encindex;
+
+static int enc_utf8_compatible_p(int enc_idx)
 {
-    if (enc == rb_usascii_encoding()) return 1;
-    if (enc == rb_utf8_encoding()) return 1;
+    if (enc_idx == usascii_encindex) return 1;
+    if (enc_idx == utf8_encindex) return 1;
     return 0;
 }
 
 static void generate_json_string(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
     fbuffer_append_char(buffer, '"');
-    if (!enc_utf8_compatible_p(rb_enc_get(obj))) {
+    if (!enc_utf8_compatible_p(RB_ENCODING_GET(obj))) {
         obj = rb_str_export_to_enc(obj, rb_utf8_encoding());
     }
     convert_UTF8_to_JSON(buffer, obj, state->ascii_only, state->script_safe);
@@ -1479,4 +1481,7 @@ void Init_generator(void)
     i_match = rb_intern("match");
     i_keys = rb_intern("keys");
     i_dup = rb_intern("dup");
+
+    usascii_encindex = rb_usascii_encindex();
+    utf8_encindex = rb_utf8_encindex();
 }

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -55,7 +55,6 @@ typedef struct JSON_Generator_StateStruct {
     long object_nl_len;
     char *array_nl;
     long array_nl_len;
-    FBuffer *object_delim2;
     long max_nesting;
     char allow_nan;
     char ascii_only;

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -55,7 +55,6 @@ typedef struct JSON_Generator_StateStruct {
     long object_nl_len;
     char *array_nl;
     long array_nl_len;
-    FBuffer *array_delim;
     FBuffer *object_delim;
     FBuffer *object_delim2;
     long max_nesting;

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -55,7 +55,6 @@ typedef struct JSON_Generator_StateStruct {
     long object_nl_len;
     char *array_nl;
     long array_nl_len;
-    FBuffer *object_delim;
     FBuffer *object_delim2;
     long max_nesting;
     char allow_nan;


### PR DESCRIPTION
Extracted from https://github.com/ruby/json/pull/562, this isn't the entirety of the PR, some of the changes are harder to cherry pick and I'll try to get them in followups. The main one missing being https://github.com/ruby/json/pull/562/commits/a81ec4770af4a2f20a9dc06d0295cf5b93a7af91

Before:

```
== Encoding small nested array (121 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json    91.687k i/100ms
                  oj   205.309k i/100ms
           rapidjson   161.648k i/100ms
Calculating -------------------------------------
                json    941.965k (± 1.4%) i/s    (1.06 μs/i) -      4.768M in   5.062573s
                  oj      2.138M (± 1.2%) i/s  (467.82 ns/i) -     10.881M in   5.091254s
           rapidjson      1.678M (± 1.9%) i/s  (596.04 ns/i) -      8.406M in   5.011931s

Comparison:
                json:   941964.8 i/s
                  oj:  2137586.5 i/s - 2.27x  faster
           rapidjson:  1677737.1 i/s - 1.78x  faster


== Encoding small hash (65 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   141.737k i/100ms
                  oj   676.871k i/100ms
           rapidjson   373.266k i/100ms
Calculating -------------------------------------
                json      1.491M (± 1.0%) i/s  (670.78 ns/i) -      7.512M in   5.039463s
                  oj      7.226M (± 1.4%) i/s  (138.39 ns/i) -     36.551M in   5.059475s
           rapidjson      3.729M (± 2.2%) i/s  (268.15 ns/i) -     18.663M in   5.007182s

Comparison:
                json:  1490798.2 i/s
                  oj:  7225766.2 i/s - 4.85x  faster
           rapidjson:  3729192.2 i/s - 2.50x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   118.000 i/100ms
                  oj   230.000 i/100ms
           rapidjson   106.000 i/100ms
Calculating -------------------------------------
                json      1.194k (± 1.2%) i/s  (837.76 μs/i) -      6.018k in   5.042338s
                  oj      2.334k (± 1.6%) i/s  (428.47 μs/i) -     11.730k in   5.027262s
           rapidjson      1.118k (± 4.7%) i/s  (894.28 μs/i) -      5.618k in   5.032519s

Comparison:
                json:     1193.7 i/s
                  oj:     2333.9 i/s - 1.96x  faster
           rapidjson:     1118.2 i/s - 1.07x  slower


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json    86.000 i/100ms
                  oj   130.000 i/100ms
           rapidjson    99.000 i/100ms
Calculating -------------------------------------
                json    872.375 (± 1.9%) i/s    (1.15 ms/i) -      4.386k in   5.029679s
                  oj      1.301k (± 2.5%) i/s  (768.48 μs/i) -      6.630k in   5.098077s
           rapidjson    986.414 (± 1.9%) i/s    (1.01 ms/i) -      4.950k in   5.019950s

Comparison:
                json:      872.4 i/s
                  oj:     1301.3 i/s - 1.49x  faster
           rapidjson:      986.4 i/s - 1.13x  faster


== Encoding canada.json (2090234 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json     1.000 i/100ms
                  oj     3.000 i/100ms
           rapidjson     1.000 i/100ms
Calculating -------------------------------------
                json     19.789 (± 0.0%) i/s   (50.53 ms/i) -     99.000 in   5.003952s
                  oj     30.697 (± 0.0%) i/s   (32.58 ms/i) -    156.000 in   5.082418s
           rapidjson     19.116 (± 0.0%) i/s   (52.31 ms/i) -     96.000 in   5.023745s

Comparison:
                json:       19.8 i/s
                  oj:       30.7 i/s - 1.55x  faster
           rapidjson:       19.1 i/s - 1.04x  slower


== Encoding many #to_json calls (2661 bytes)
oj does not match expected output. Skipping
rapidjson unsupported (Invalid object key type: Object)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json     2.022k i/100ms
Calculating -------------------------------------
                json     22.241k (± 1.3%) i/s   (44.96 μs/i) -    111.210k in   5.001111s
```

After:

```
== Encoding small nested array (121 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   145.767k i/100ms
                  oj   209.915k i/100ms
           rapidjson   167.157k i/100ms
Calculating -------------------------------------
                json      1.499M (± 1.2%) i/s  (666.93 ns/i) -      7.580M in   5.056036s
                  oj      2.134M (± 1.7%) i/s  (468.53 ns/i) -     10.706M in   5.017418s
           rapidjson      1.723M (± 2.1%) i/s  (580.47 ns/i) -      8.692M in   5.047929s

Comparison:
                json:  1499413.4 i/s
                  oj:  2134324.3 i/s - 1.42x  faster
           rapidjson:  1722754.0 i/s - 1.15x  faster


== Encoding small hash (65 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   194.424k i/100ms
                  oj   677.724k i/100ms
           rapidjson   366.156k i/100ms
Calculating -------------------------------------
                json      2.076M (± 1.5%) i/s  (481.61 ns/i) -     10.499M in   5.057577s
                  oj      7.115M (± 1.7%) i/s  (140.55 ns/i) -     35.919M in   5.050125s
           rapidjson      3.848M (± 3.0%) i/s  (259.90 ns/i) -     19.406M in   5.048376s

Comparison:
                json:  2076365.8 i/s
                  oj:  7114759.1 i/s - 3.43x  faster
           rapidjson:  3847588.8 i/s - 1.85x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   146.000 i/100ms
                  oj   221.000 i/100ms
           rapidjson   112.000 i/100ms
Calculating -------------------------------------
                json      1.465k (± 2.3%) i/s  (682.81 μs/i) -      7.446k in   5.086936s
                  oj      2.305k (± 2.3%) i/s  (433.85 μs/i) -     11.713k in   5.084603s
           rapidjson      1.083k (± 2.7%) i/s  (923.12 μs/i) -      5.488k in   5.069470s

Comparison:
                json:     1464.5 i/s
                  oj:     2304.9 i/s - 1.57x  faster
           rapidjson:     1083.3 i/s - 1.35x  slower


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   111.000 i/100ms
                  oj   128.000 i/100ms
           rapidjson    96.000 i/100ms
Calculating -------------------------------------
                json      1.126k (± 2.7%) i/s  (887.78 μs/i) -      5.661k in   5.029478s
                  oj      1.283k (± 2.7%) i/s  (779.34 μs/i) -      6.528k in   5.091464s
           rapidjson    986.411 (± 1.5%) i/s    (1.01 ms/i) -      4.992k in   5.062001s

Comparison:
                json:     1126.4 i/s
                  oj:     1283.1 i/s - 1.14x  faster
           rapidjson:      986.4 i/s - 1.14x  slower


== Encoding canada.json (2090234 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json     1.000 i/100ms
                  oj     3.000 i/100ms
           rapidjson     1.000 i/100ms
Calculating -------------------------------------
                json     19.740 (± 0.0%) i/s   (50.66 ms/i) -     99.000 in   5.016553s
                  oj     30.289 (± 6.6%) i/s   (33.02 ms/i) -    153.000 in   5.081497s
           rapidjson     19.171 (± 0.0%) i/s   (52.16 ms/i) -     96.000 in   5.008856s

Comparison:
                json:       19.7 i/s
                  oj:       30.3 i/s - 1.53x  faster
           rapidjson:       19.2 i/s - 1.03x  slower


== Encoding many #to_json calls (2661 bytes)
oj does not match expected output. Skipping
rapidjson unsupported (Invalid object key type: Object)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json     2.267k i/100ms
Calculating -------------------------------------
                json     22.548k (± 1.3%) i/s   (44.35 μs/i) -    113.350k in   5.027945s
```

FYI @mame 