### PR TITLE
Migrate some C code to Ruby

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -16,11 +16,7 @@ static VALUE mJSON, mExt, mGenerator, cState, mGeneratorMethods, mObject,
              mTrueClass, mFalseClass, mNilClass, eGeneratorError,
              eNestingError;
 
-static ID i_to_s, i_to_json, i_new, i_indent, i_space, i_space_before,
-          i_object_nl, i_array_nl, i_max_nesting, i_allow_nan, i_ascii_only,
-          i_pack, i_unpack, i_create_id, i_extend, i_key_p,
-          i_aref, i_send, i_respond_to_p, i_match, i_keys, i_depth,
-          i_buffer_initial_length, i_dup, i_script_safe, i_escape_slash, i_strict;
+static ID i_to_s, i_to_json, i_new, i_pack, i_unpack, i_create_id, i_extend;
 
 /* Converts in_string to a JSON string (without the wrapping '"'
  * characters) in FBuffer out_buffer.
@@ -451,180 +447,10 @@ static const rb_data_type_t JSON_Generator_State_type = {
 static VALUE cState_s_allocate(VALUE klass)
 {
     JSON_Generator_State *state;
-    return TypedData_Make_Struct(klass, JSON_Generator_State,
-				 &JSON_Generator_State_type, state);
-}
-
-/*
- * call-seq: configure(opts)
- *
- * Configure this State instance with the Hash _opts_, and return
- * itself.
- */
-static VALUE cState_configure(VALUE self, VALUE opts)
-{
-    VALUE tmp;
-    GET_STATE(self);
-    tmp = rb_check_convert_type(opts, T_HASH, "Hash", "to_hash");
-    if (NIL_P(tmp)) tmp = rb_convert_type(opts, T_HASH, "Hash", "to_h");
-    opts = tmp;
-    tmp = rb_hash_aref(opts, ID2SYM(i_indent));
-    if (RTEST(tmp)) {
-        unsigned long len;
-        Check_Type(tmp, T_STRING);
-        len = RSTRING_LEN(tmp);
-        state->indent = fstrndup(RSTRING_PTR(tmp), len + 1);
-        state->indent_len = len;
-    }
-    tmp = rb_hash_aref(opts, ID2SYM(i_space));
-    if (RTEST(tmp)) {
-        unsigned long len;
-        Check_Type(tmp, T_STRING);
-        len = RSTRING_LEN(tmp);
-        state->space = fstrndup(RSTRING_PTR(tmp), len + 1);
-        state->space_len = len;
-    }
-    tmp = rb_hash_aref(opts, ID2SYM(i_space_before));
-    if (RTEST(tmp)) {
-        unsigned long len;
-        Check_Type(tmp, T_STRING);
-        len = RSTRING_LEN(tmp);
-        state->space_before = fstrndup(RSTRING_PTR(tmp), len + 1);
-        state->space_before_len = len;
-    }
-    tmp = rb_hash_aref(opts, ID2SYM(i_array_nl));
-    if (RTEST(tmp)) {
-        unsigned long len;
-        Check_Type(tmp, T_STRING);
-        len = RSTRING_LEN(tmp);
-        state->array_nl = fstrndup(RSTRING_PTR(tmp), len + 1);
-        state->array_nl_len = len;
-    }
-    tmp = rb_hash_aref(opts, ID2SYM(i_object_nl));
-    if (RTEST(tmp)) {
-        unsigned long len;
-        Check_Type(tmp, T_STRING);
-        len = RSTRING_LEN(tmp);
-        state->object_nl = fstrndup(RSTRING_PTR(tmp), len + 1);
-        state->object_nl_len = len;
-    }
-    tmp = ID2SYM(i_max_nesting);
+    VALUE obj = TypedData_Make_Struct(klass, JSON_Generator_State, &JSON_Generator_State_type, state);
     state->max_nesting = 100;
-    if (option_given_p(opts, tmp)) {
-        VALUE max_nesting = rb_hash_aref(opts, tmp);
-        if (RTEST(max_nesting)) {
-            Check_Type(max_nesting, T_FIXNUM);
-            state->max_nesting = FIX2LONG(max_nesting);
-        } else {
-            state->max_nesting = 0;
-        }
-    }
-    tmp = ID2SYM(i_depth);
-    state->depth = 0;
-    if (option_given_p(opts, tmp)) {
-        VALUE depth = rb_hash_aref(opts, tmp);
-        if (RTEST(depth)) {
-            Check_Type(depth, T_FIXNUM);
-            state->depth = FIX2LONG(depth);
-        } else {
-            state->depth = 0;
-        }
-    }
-    tmp = ID2SYM(i_buffer_initial_length);
-    if (option_given_p(opts, tmp)) {
-        VALUE buffer_initial_length = rb_hash_aref(opts, tmp);
-        if (RTEST(buffer_initial_length)) {
-            long initial_length;
-            Check_Type(buffer_initial_length, T_FIXNUM);
-            initial_length = FIX2LONG(buffer_initial_length);
-            if (initial_length > 0) state->buffer_initial_length = initial_length;
-        }
-    }
-    tmp = rb_hash_aref(opts, ID2SYM(i_allow_nan));
-    state->allow_nan = RTEST(tmp);
-    tmp = rb_hash_aref(opts, ID2SYM(i_ascii_only));
-    state->ascii_only = RTEST(tmp);
-    tmp = rb_hash_aref(opts, ID2SYM(i_script_safe));
-    state->script_safe = RTEST(tmp);
-    if (!state->script_safe) {
-        tmp = rb_hash_aref(opts, ID2SYM(i_escape_slash));
-        state->script_safe = RTEST(tmp);
-    }
-    tmp = rb_hash_aref(opts, ID2SYM(i_strict));
-    state->strict = RTEST(tmp);
-    return self;
-}
-
-static void set_state_ivars(VALUE hash, VALUE state)
-{
-    VALUE ivars = rb_obj_instance_variables(state);
-    int i = 0;
-    for (i = 0; i < RARRAY_LEN(ivars); i++) {
-        VALUE key = rb_funcall(rb_ary_entry(ivars, i), i_to_s, 0);
-        long key_len = RSTRING_LEN(key);
-        VALUE value = rb_iv_get(state, StringValueCStr(key));
-        rb_hash_aset(hash, rb_str_intern(rb_str_substr(key, 1, key_len - 1)), value);
-    }
-}
-
-/*
- * call-seq: to_h
- *
- * Returns the configuration instance variables as a hash, that can be
- * passed to the configure method.
- */
-static VALUE cState_to_h(VALUE self)
-{
-    VALUE result = rb_hash_new();
-    GET_STATE(self);
-    set_state_ivars(result, self);
-    rb_hash_aset(result, ID2SYM(i_indent), rb_str_new(state->indent, state->indent_len));
-    rb_hash_aset(result, ID2SYM(i_space), rb_str_new(state->space, state->space_len));
-    rb_hash_aset(result, ID2SYM(i_space_before), rb_str_new(state->space_before, state->space_before_len));
-    rb_hash_aset(result, ID2SYM(i_object_nl), rb_str_new(state->object_nl, state->object_nl_len));
-    rb_hash_aset(result, ID2SYM(i_array_nl), rb_str_new(state->array_nl, state->array_nl_len));
-    rb_hash_aset(result, ID2SYM(i_allow_nan), state->allow_nan ? Qtrue : Qfalse);
-    rb_hash_aset(result, ID2SYM(i_ascii_only), state->ascii_only ? Qtrue : Qfalse);
-    rb_hash_aset(result, ID2SYM(i_max_nesting), LONG2FIX(state->max_nesting));
-    rb_hash_aset(result, ID2SYM(i_script_safe), state->script_safe ? Qtrue : Qfalse);
-    rb_hash_aset(result, ID2SYM(i_strict), state->strict ? Qtrue : Qfalse);
-    rb_hash_aset(result, ID2SYM(i_depth), LONG2FIX(state->depth));
-    rb_hash_aset(result, ID2SYM(i_buffer_initial_length), LONG2FIX(state->buffer_initial_length));
-    return result;
-}
-
-/*
-* call-seq: [](name)
-*
-* Returns the value returned by method +name+.
-*/
-static VALUE cState_aref(VALUE self, VALUE name)
-{
-    name = rb_funcall(name, i_to_s, 0);
-    if (RTEST(rb_funcall(self, i_respond_to_p, 1, name))) {
-        return rb_funcall(self, i_send, 1, name);
-    } else {
-        return rb_attr_get(self, rb_intern_str(rb_str_concat(rb_str_new2("@"), name)));
-    }
-}
-
-/*
-* call-seq: []=(name, value)
-*
-* Sets the attribute name to value.
-*/
-static VALUE cState_aset(VALUE self, VALUE name, VALUE value)
-{
-    VALUE name_writer;
-
-    name = rb_funcall(name, i_to_s, 0);
-    name_writer = rb_str_cat2(rb_str_dup(name), "=");
-    if (RTEST(rb_funcall(self, i_respond_to_p, 1, name_writer))) {
-        return rb_funcall(self, i_send, 2, name_writer, value);
-    } else {
-        rb_ivar_set(self, rb_intern_str(rb_str_concat(rb_str_new2("@"), name)), value);
-    }
-    return Qnil;
+    state->buffer_initial_length = FBUFFER_INITIAL_LENGTH_DEFAULT;
+    return obj;
 }
 
 struct hash_foreach_arg {
@@ -931,37 +757,6 @@ static VALUE cState_generate(VALUE self, VALUE obj)
     GET_STATE(self);
     (void)state;
     return result;
-}
-
-/*
- * call-seq: new(opts = {})
- *
- * Instantiates a new State object, configured by _opts_.
- *
- * _opts_ can have the following keys:
- *
- * * *indent*: a string used to indent levels (default: ''),
- * * *space*: a string that is put after, a : or , delimiter (default: ''),
- * * *space_before*: a string that is put before a : pair delimiter (default: ''),
- * * *object_nl*: a string that is put at the end of a JSON object (default: ''),
- * * *array_nl*: a string that is put at the end of a JSON array (default: ''),
- * * *allow_nan*: true if NaN, Infinity, and -Infinity should be
- *   generated, otherwise an exception is thrown, if these values are
- *   encountered. This options defaults to false.
- * * *ascii_only*: true if only ASCII characters should be generated. This
- *   option defaults to false.
- * * *buffer_initial_length*: sets the initial length of the generator's
- *   internal buffer.
- */
-static VALUE cState_initialize(int argc, VALUE *argv, VALUE self)
-{
-    VALUE opts;
-    GET_STATE(self);
-    state->max_nesting = 100;
-    state->buffer_initial_length = FBUFFER_INITIAL_LENGTH_DEFAULT;
-    rb_scan_args(argc, argv, "01", &opts);
-    if (!NIL_P(opts)) cState_configure(self, opts);
-    return self;
 }
 
 /*
@@ -1295,6 +1090,18 @@ static VALUE cState_allow_nan_p(VALUE self)
 }
 
 /*
+ * call-seq: allow_nan=(enable)
+ *
+ * This sets whether or not to serialize NaN, Infinity, and -Infinity
+ */
+static VALUE cState_allow_nan_set(VALUE self, VALUE enable)
+{
+    GET_STATE(self);
+    state->allow_nan = RTEST(enable);
+    return Qnil;
+}
+
+/*
  * call-seq: ascii_only?
  *
  * Returns true, if only ASCII characters should be generated. Otherwise
@@ -1304,6 +1111,18 @@ static VALUE cState_ascii_only_p(VALUE self)
 {
     GET_STATE(self);
     return state->ascii_only ? Qtrue : Qfalse;
+}
+
+/*
+ * call-seq: ascii_only=(enable)
+ *
+ * This sets whether only ASCII characters should be generated.
+ */
+static VALUE cState_ascii_only_set(VALUE self, VALUE enable)
+{
+    GET_STATE(self);
+    state->ascii_only = RTEST(enable);
+    return Qnil;
 }
 
 /*
@@ -1384,7 +1203,6 @@ void Init_generator(void)
     cState = rb_define_class_under(mGenerator, "State", rb_cObject);
     rb_define_alloc_func(cState, cState_s_allocate);
     rb_define_singleton_method(cState, "from_state", cState_from_state_s, 1);
-    rb_define_method(cState, "initialize", cState_initialize, -1);
     rb_define_method(cState, "initialize_copy", cState_init_copy, 1);
     rb_define_method(cState, "indent", cState_indent, 0);
     rb_define_method(cState, "indent=", cState_indent_set, 1);
@@ -1409,17 +1227,13 @@ void Init_generator(void)
     rb_define_method(cState, "strict=", cState_strict_set, 1);
     rb_define_method(cState, "check_circular?", cState_check_circular_p, 0);
     rb_define_method(cState, "allow_nan?", cState_allow_nan_p, 0);
+    rb_define_method(cState, "allow_nan=", cState_allow_nan_set, 1);
     rb_define_method(cState, "ascii_only?", cState_ascii_only_p, 0);
+    rb_define_method(cState, "ascii_only=", cState_ascii_only_set, 1);
     rb_define_method(cState, "depth", cState_depth, 0);
     rb_define_method(cState, "depth=", cState_depth_set, 1);
     rb_define_method(cState, "buffer_initial_length", cState_buffer_initial_length, 0);
     rb_define_method(cState, "buffer_initial_length=", cState_buffer_initial_length_set, 1);
-    rb_define_method(cState, "configure", cState_configure, 1);
-    rb_define_alias(cState, "merge", "configure");
-    rb_define_method(cState, "to_h", cState_to_h, 0);
-    rb_define_alias(cState, "to_hash", "to_h");
-    rb_define_method(cState, "[]", cState_aref, 1);
-    rb_define_method(cState, "[]=", cState_aset, 2);
     rb_define_method(cState, "generate", cState_generate, 1);
 
     mGeneratorMethods = rb_define_module_under(mGenerator, "GeneratorMethods");
@@ -1457,30 +1271,10 @@ void Init_generator(void)
     i_to_s = rb_intern("to_s");
     i_to_json = rb_intern("to_json");
     i_new = rb_intern("new");
-    i_indent = rb_intern("indent");
-    i_space = rb_intern("space");
-    i_space_before = rb_intern("space_before");
-    i_object_nl = rb_intern("object_nl");
-    i_array_nl = rb_intern("array_nl");
-    i_max_nesting = rb_intern("max_nesting");
-    i_script_safe = rb_intern("script_safe");
-    i_escape_slash = rb_intern("escape_slash");
-    i_strict = rb_intern("strict");
-    i_allow_nan = rb_intern("allow_nan");
-    i_ascii_only = rb_intern("ascii_only");
-    i_depth = rb_intern("depth");
-    i_buffer_initial_length = rb_intern("buffer_initial_length");
     i_pack = rb_intern("pack");
     i_unpack = rb_intern("unpack");
     i_create_id = rb_intern("create_id");
     i_extend = rb_intern("extend");
-    i_key_p = rb_intern("key?");
-    i_aref = rb_intern("[]");
-    i_send = rb_intern("__send__");
-    i_respond_to_p = rb_intern("respond_to?");
-    i_match = rb_intern("match");
-    i_keys = rb_intern("keys");
-    i_dup = rb_intern("dup");
 
     usascii_encindex = rb_usascii_encindex();
     utf8_encindex = rb_utf8_encindex();

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -5,16 +5,7 @@
 #define RB_UNLIKELY(cond) (cond)
 #endif
 
-static VALUE mJSON, mExt, mGenerator, cState, mGeneratorMethods, mObject,
-             mHash, mArray,
-#ifdef RUBY_INTEGER_UNIFICATION
-             mInteger,
-#else
-             mFixnum, mBignum,
-#endif
-             mFloat, mString, mString_Extend,
-             mTrueClass, mFalseClass, mNilClass, eGeneratorError,
-             eNestingError;
+static VALUE mJSON, cState, mString_Extend, eGeneratorError, eNestingError;
 
 static ID i_to_s, i_to_json, i_new, i_pack, i_unpack, i_create_id, i_extend;
 
@@ -1192,8 +1183,8 @@ void Init_generator(void)
     rb_require("json/common");
 
     mJSON = rb_define_module("JSON");
-    mExt = rb_define_module_under(mJSON, "Ext");
-    mGenerator = rb_define_module_under(mExt, "Generator");
+    VALUE mExt = rb_define_module_under(mJSON, "Ext");
+    VALUE mGenerator = rb_define_module_under(mExt, "Generator");
 
     eGeneratorError = rb_path2class("JSON::GeneratorError");
     eNestingError = rb_path2class("JSON::NestingError");
@@ -1236,36 +1227,46 @@ void Init_generator(void)
     rb_define_method(cState, "buffer_initial_length=", cState_buffer_initial_length_set, 1);
     rb_define_method(cState, "generate", cState_generate, 1);
 
-    mGeneratorMethods = rb_define_module_under(mGenerator, "GeneratorMethods");
-    mObject = rb_define_module_under(mGeneratorMethods, "Object");
+    VALUE mGeneratorMethods = rb_define_module_under(mGenerator, "GeneratorMethods");
+
+    VALUE mObject = rb_define_module_under(mGeneratorMethods, "Object");
     rb_define_method(mObject, "to_json", mObject_to_json, -1);
-    mHash = rb_define_module_under(mGeneratorMethods, "Hash");
+
+    VALUE mHash = rb_define_module_under(mGeneratorMethods, "Hash");
     rb_define_method(mHash, "to_json", mHash_to_json, -1);
-    mArray = rb_define_module_under(mGeneratorMethods, "Array");
+
+    VALUE mArray = rb_define_module_under(mGeneratorMethods, "Array");
     rb_define_method(mArray, "to_json", mArray_to_json, -1);
+
 #ifdef RUBY_INTEGER_UNIFICATION
-    mInteger = rb_define_module_under(mGeneratorMethods, "Integer");
+    VALUE mInteger = rb_define_module_under(mGeneratorMethods, "Integer");
     rb_define_method(mInteger, "to_json", mInteger_to_json, -1);
 #else
-    mFixnum = rb_define_module_under(mGeneratorMethods, "Fixnum");
+    VALUE mFixnum = rb_define_module_under(mGeneratorMethods, "Fixnum");
     rb_define_method(mFixnum, "to_json", mFixnum_to_json, -1);
-    mBignum = rb_define_module_under(mGeneratorMethods, "Bignum");
+
+    VALUE mBignum = rb_define_module_under(mGeneratorMethods, "Bignum");
     rb_define_method(mBignum, "to_json", mBignum_to_json, -1);
 #endif
-    mFloat = rb_define_module_under(mGeneratorMethods, "Float");
+    VALUE mFloat = rb_define_module_under(mGeneratorMethods, "Float");
     rb_define_method(mFloat, "to_json", mFloat_to_json, -1);
-    mString = rb_define_module_under(mGeneratorMethods, "String");
+
+    VALUE mString = rb_define_module_under(mGeneratorMethods, "String");
     rb_define_singleton_method(mString, "included", mString_included_s, 1);
     rb_define_method(mString, "to_json", mString_to_json, -1);
     rb_define_method(mString, "to_json_raw", mString_to_json_raw, -1);
     rb_define_method(mString, "to_json_raw_object", mString_to_json_raw_object, 0);
+
     mString_Extend = rb_define_module_under(mString, "Extend");
     rb_define_method(mString_Extend, "json_create", mString_Extend_json_create, 1);
-    mTrueClass = rb_define_module_under(mGeneratorMethods, "TrueClass");
+
+    VALUE mTrueClass = rb_define_module_under(mGeneratorMethods, "TrueClass");
     rb_define_method(mTrueClass, "to_json", mTrueClass_to_json, -1);
-    mFalseClass = rb_define_module_under(mGeneratorMethods, "FalseClass");
+
+    VALUE mFalseClass = rb_define_module_under(mGeneratorMethods, "FalseClass");
     rb_define_method(mFalseClass, "to_json", mFalseClass_to_json, -1);
-    mNilClass = rb_define_module_under(mGeneratorMethods, "NilClass");
+
+    VALUE mNilClass = rb_define_module_under(mGeneratorMethods, "NilClass");
     rb_define_method(mNilClass, "to_json", mNilClass_to_json, -1);
 
     i_to_s = rb_intern("to_s");

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -103,8 +103,6 @@ static VALUE mNilClass_to_json(int argc, VALUE *argv, VALUE self);
 static VALUE mObject_to_json(int argc, VALUE *argv, VALUE self);
 static void State_free(void *state);
 static VALUE cState_s_allocate(VALUE klass);
-static VALUE cState_configure(VALUE self, VALUE opts);
-static VALUE cState_to_h(VALUE self);
 static void generate_json(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
@@ -120,7 +118,6 @@ static void generate_json_bignum(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
 static void generate_json_float(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static VALUE cState_partial_generate(VALUE self, VALUE obj);
 static VALUE cState_generate(VALUE self, VALUE obj);
-static VALUE cState_initialize(int argc, VALUE *argv, VALUE self);
 static VALUE cState_from_state_s(VALUE self, VALUE opts);
 static VALUE cState_indent(VALUE self);
 static VALUE cState_indent_set(VALUE self, VALUE indent);

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -576,13 +576,12 @@ module JSON
     # Sets or returns the default options for the JSON.dump method.
     # Initially:
     #   opts = JSON.dump_default_options
-    #   opts # => {:max_nesting=>false, :allow_nan=>true, :script_safe=>false}
+    #   opts # => {:max_nesting=>false, :allow_nan=>true}
     attr_accessor :dump_default_options
   end
   self.dump_default_options = {
     :max_nesting => false,
     :allow_nan   => true,
-    :script_safe => false,
   }
 
   # :call-seq:

--- a/lib/json/ext.rb
+++ b/lib/json/ext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json/common'
 
 module JSON
@@ -13,6 +15,9 @@ module JSON
     else
       require 'json/ext/parser'
       require 'json/ext/generator'
+      unless RUBY_ENGINE == 'jruby'
+        require 'json/ext/generator/state'
+      end
       $DEBUG and warn "Using Ext extension for JSON."
       JSON.parser = Parser
       JSON.generator = Generator

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module JSON
+  module Ext
+    module Generator
+      class State
+        # call-seq: new(opts = {})
+        #
+        # Instantiates a new State object, configured by _opts_.
+        #
+        # _opts_ can have the following keys:
+        #
+        # * *indent*: a string used to indent levels (default: ''),
+        # * *space*: a string that is put after, a : or , delimiter (default: ''),
+        # * *space_before*: a string that is put before a : pair delimiter (default: ''),
+        # * *object_nl*: a string that is put at the end of a JSON object (default: ''),
+        # * *array_nl*: a string that is put at the end of a JSON array (default: ''),
+        # * *allow_nan*: true if NaN, Infinity, and -Infinity should be
+        #   generated, otherwise an exception is thrown, if these values are
+        #   encountered. This options defaults to false.
+        # * *ascii_only*: true if only ASCII characters should be generated. This
+        #   option defaults to false.
+        # * *buffer_initial_length*: sets the initial length of the generator's
+        #   internal buffer.
+        def initialize(opts = nil)
+          if opts && !opts.empty?
+            configure(opts)
+          end
+        end
+
+        # call-seq: configure(opts)
+        #
+        # Configure this State instance with the Hash _opts_, and return
+        # itself.
+        def configure(opts)
+          unless opts.is_a?(Hash)
+            if opts.respond_to?(:to_hash)
+              opts = opts.to_hash
+            elsif opts.respond_to?(:to_h)
+              opts = opts.to_h
+            else
+              raise TypeError, "can't convert #{opts.class} into Hash"
+            end
+          end
+
+          self.indent = opts[:indent] if opts.key?(:indent)
+          self.space = opts[:space] if opts.key?(:space)
+          self.space_before = opts[:space_before] if opts.key?(:space_before)
+          self.array_nl = opts[:array_nl] if opts.key?(:array_nl)
+          self.object_nl = opts[:object_nl] if opts.key?(:object_nl)
+          self.max_nesting = opts[:max_nesting] || 0 if opts.key?(:max_nesting)
+          self.depth = opts[:depth] if opts.key?(:depth)
+          self.buffer_initial_length = opts[:buffer_initial_length] if opts.key?(:buffer_initial_length)
+          self.allow_nan = opts[:allow_nan] if opts.key?(:allow_nan)
+          self.ascii_only = opts[:ascii_only] if opts.key?(:ascii_only)
+
+          if opts.key?(:script_safe)
+            self.script_safe = opts[:script_safe]
+          elsif opts.key?(:escape_slash)
+            self.script_safe = opts[:escape_slash]
+          end
+
+          self.strict = opts[:strict] if opts[:strict]
+
+          self
+        end
+
+        alias_method :merge, :configure
+
+        # call-seq: to_h
+        #
+        # Returns the configuration instance variables as a hash, that can be
+        # passed to the configure method.
+        def to_h
+          result = {
+            indent: indent,
+            space: space,
+            space_before: space_before,
+            object_nl: object_nl,
+            array_nl: array_nl,
+            allow_nan: allow_nan?,
+            ascii_only: ascii_only?,
+            max_nesting: max_nesting,
+            script_safe: script_safe?,
+            strict: strict?,
+            depth: depth,
+            buffer_initial_length: buffer_initial_length,
+          }
+
+          instance_variables.each do |iv|
+            iv = iv.to_s[1..-1]
+            result[iv.to_sym] = self[iv]
+          end
+
+          result
+        end
+
+        alias_method :to_hash, :to_h
+
+        # call-seq: [](name)
+        #
+        # Returns the value returned by method +name+.
+        def [](name)
+          if respond_to?(name)
+            __send__(name)
+          else
+            instance_variable_get("@#{name}") if
+              instance_variables.include?("@#{name}".to_sym) # avoid warning
+          end
+        end
+
+        # call-seq: []=(name, value)
+        #
+        # Sets the attribute name to value.
+        def []=(name, value)
+          if respond_to?(name_writer = "#{name}=")
+            __send__ name_writer, value
+          else
+            instance_variable_set "@#{name}", value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -43,24 +43,34 @@ module JSON
             end
           end
 
-          self.indent = opts[:indent] if opts.key?(:indent)
-          self.space = opts[:space] if opts.key?(:space)
-          self.space_before = opts[:space_before] if opts.key?(:space_before)
-          self.array_nl = opts[:array_nl] if opts.key?(:array_nl)
-          self.object_nl = opts[:object_nl] if opts.key?(:object_nl)
-          self.max_nesting = opts[:max_nesting] || 0 if opts.key?(:max_nesting)
-          self.depth = opts[:depth] if opts.key?(:depth)
-          self.buffer_initial_length = opts[:buffer_initial_length] if opts.key?(:buffer_initial_length)
-          self.allow_nan = opts[:allow_nan] if opts.key?(:allow_nan)
-          self.ascii_only = opts[:ascii_only] if opts.key?(:ascii_only)
-
-          if opts.key?(:script_safe)
-            self.script_safe = opts[:script_safe]
-          elsif opts.key?(:escape_slash)
-            self.script_safe = opts[:escape_slash]
+          opts.each do |key, value|
+            case key
+            when :indent
+              self.indent = value
+            when :space
+              self.space = value
+            when :space_before
+              self.space_before = value
+            when :array_nl
+              self.array_nl = value
+            when :object_nl
+              self.object_nl = value
+            when :max_nesting
+              self.max_nesting = value || 0
+            when :depth
+              self.depth = value
+            when :buffer_initial_length
+              self.buffer_initial_length = value
+            when :allow_nan
+              self.allow_nan = value
+            when :ascii_only
+              self.ascii_only = value
+            when :script_safe, :escape_slash
+              self.script_safe = value
+            when :strict
+              self.strict = value
+            end
           end
-
-          self.strict = opts[:strict] if opts[:strict]
 
           self
         end


### PR DESCRIPTION
All these methods aren't hotspot and much simpler to implement in Ruby than C. Some code could even be shared with the "pure" implementation but it's not a big deal.

Also this whole "`Generator::State` can be used as a Hash" scream YAGNI, not sure if we want to deprecate it, but definitely something we don't care about optimizing.

Overall this optimize the happy path for instantiating `Generator::State`, which is about half the time spent in micro-benchmarks:

Before:

```
== Encoding small nested array (121 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   156.832k i/100ms
                  oj   209.769k i/100ms
           rapidjson   162.922k i/100ms
Calculating -------------------------------------
                json      1.599M (± 2.5%) i/s  (625.34 ns/i) -      7.998M in   5.005110s
                  oj      2.137M (± 1.5%) i/s  (467.99 ns/i) -     10.698M in   5.007806s
           rapidjson      1.677M (± 3.5%) i/s  (596.31 ns/i) -      8.472M in   5.059515s

Comparison:
                json:  1599141.2 i/s
                  oj:  2136785.3 i/s - 1.34x  faster
           rapidjson:  1676977.2 i/s - same-ish: difference falls within error

== Encoding small hash (65 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   216.464k i/100ms
                  oj   661.328k i/100ms
           rapidjson   324.434k i/100ms
Calculating -------------------------------------
                json      2.301M (± 1.7%) i/s  (434.57 ns/i) -     11.689M in   5.081278s
                  oj      7.244M (± 1.2%) i/s  (138.05 ns/i) -     36.373M in   5.021985s
           rapidjson      3.323M (± 2.9%) i/s  (300.96 ns/i) -     16.871M in   5.081696s

Comparison:
                json:  2301142.2 i/s
                  oj:  7243770.3 i/s - 3.15x  faster
           rapidjson:  3322673.0 i/s - 1.44x  faster
```

After:

```
== Encoding small nested array (121 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   168.087k i/100ms
                  oj   208.872k i/100ms
           rapidjson   149.909k i/100ms
Calculating -------------------------------------
                json      1.761M (± 1.1%) i/s  (567.90 ns/i) -      8.909M in   5.059794s
                  oj      2.144M (± 0.9%) i/s  (466.37 ns/i) -     10.861M in   5.065903s
           rapidjson      1.692M (± 1.7%) i/s  (591.04 ns/i) -      8.545M in   5.051808s

Comparison:
                json:  1760868.2 i/s
                  oj:  2144205.9 i/s - 1.22x  faster
           rapidjson:  1691941.1 i/s - 1.04x  slower

== Encoding small hash (65 bytes)
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                json   242.957k i/100ms
                  oj   675.217k i/100ms
           rapidjson   355.040k i/100ms
Calculating -------------------------------------
                json      2.569M (± 1.5%) i/s  (389.22 ns/i) -     12.877M in   5.013095s
                  oj      7.128M (± 2.3%) i/s  (140.30 ns/i) -     35.787M in   5.023594s
           rapidjson      3.656M (± 3.1%) i/s  (273.50 ns/i) -     18.462M in   5.054558s

Comparison:
                json:  2569217.5 i/s
                  oj:  7127705.6 i/s - 2.77x  faster
           rapidjson:  3656285.0 i/s - 1.42x  faster
```