### PR TITLE
Fix State#max_nesting=

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1177,7 +1177,8 @@ static VALUE cState_max_nesting_set(VALUE self, VALUE depth)
 {
     GET_STATE(self);
     Check_Type(depth, T_FIXNUM);
-    return state->max_nesting = FIX2LONG(depth);
+    state->max_nesting = FIX2LONG(depth);
+    return Qnil;
 }
 
 /*


### PR DESCRIPTION
Returning state->max_nesting is not valid because it's not a Ruby object.