### PR TITLE
Speedup Parser initialization

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -74,7 +74,7 @@ static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
-          i_object_class, i_array_class, i_decimal_class, i_key_p,
+          i_object_class, i_array_class, i_decimal_class,
           i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
           i_leftshift, i_new, i_try_convert, i_freeze, i_uminus;
 
@@ -2180,7 +2180,6 @@ void Init_parser(void)
     i_decimal_class = rb_intern("decimal_class");
     i_match = rb_intern("match");
     i_match_string = rb_intern("match_string");
-    i_key_p = rb_intern("key?");
     i_deep_const_get = rb_intern("deep_const_get");
     i_aset = rb_intern("[]=");
     i_aref = rb_intern("[]");

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -7,7 +7,7 @@
 # define MAYBE_UNUSED(x) x
 #endif
 
-#define option_given_p(opts, key) RTEST(rb_funcall(opts, i_key_p, 1, key))
+#define option_given_p(opts, key) (rb_hash_lookup2(opts, key, Qundef) != Qundef)
 
 typedef struct JSON_ParserStruct {
     VALUE Vsource;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -72,7 +72,7 @@ static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
-          i_object_class, i_array_class, i_decimal_class, i_key_p,
+          i_object_class, i_array_class, i_decimal_class,
           i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
           i_leftshift, i_new, i_try_convert, i_freeze, i_uminus;
 
@@ -940,7 +940,6 @@ void Init_parser(void)
     i_decimal_class = rb_intern("decimal_class");
     i_match = rb_intern("match");
     i_match_string = rb_intern("match_string");
-    i_key_p = rb_intern("key?");
     i_deep_const_get = rb_intern("deep_const_get");
     i_aset = rb_intern("[]=");
     i_aref = rb_intern("[]");


### PR DESCRIPTION
Extracted from: https://github.com/ruby/json/pull/512

Use `rb_hash_lookup2` to check for hash key existence instead of going through `rb_funcall`.

FYI: @luke-gru