### PR TITLE
Reduce allocations in `parse` and `load` argument handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -291,8 +291,7 @@
 
 ## 2011-06-20 (1.5.3)
   * Alias State#configure method as State#merge to increase duck type synonymy with Hash.
-	* Add `as_json` methods in json/add/core, so rails can create its json objects
-	  the new way.
+  * Add `as_json` methods in json/add/core, so rails can create its json objects the new way.
 
 ## 2011-05-11 (1.5.2)
   * Apply documentation patch by Cory Monty <cory.monty@gmail.com>.

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -61,7 +61,7 @@ typedef struct JSON_Generator_StateStruct {
                                                                                                 \
     rb_scan_args(argc, argv, "01", &Vstate);                                                    \
     Vstate = cState_from_state_s(cState, Vstate);                                               \
-    TypedData_Get_Struct(Vstate, JSON_Generator_State, &JSON_Generator_State_type, state);	\
+    TypedData_Get_Struct(Vstate, JSON_Generator_State, &JSON_Generator_State_type, state);      \
     buffer = cState_prepare_buffer(Vstate);                                                     \
     generate_json_##type(buffer, Vstate, state, self);                                          \
     return fbuffer_to_s(buffer)

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1824,7 +1824,15 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
     if (json->Vsource) {
         rb_raise(rb_eTypeError, "already initialized instance");
     }
-    rb_scan_args(argc, argv, "1:", &source, &opts);
+
+    rb_check_arity(argc, 1, 2);
+    source = argv[0];
+    opts = Qnil;
+    if (argc == 2) {
+        opts = argv[1];
+        Check_Type(opts, T_HASH);
+    }
+
     if (!NIL_P(opts)) {
 	VALUE tmp = ID2SYM(i_max_nesting);
 	if (option_given_p(opts, tmp)) {
@@ -1916,7 +1924,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1920 "parser.c"
+#line 1928 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1924,7 +1932,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 828 "parser.rl"
+#line 836 "parser.rl"
 
 
 /*
@@ -1942,16 +1950,16 @@ static VALUE cParser_parse(VALUE self)
   GET_PARSER;
 
 
-#line 1946 "parser.c"
+#line 1954 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 845 "parser.rl"
+#line 853 "parser.rl"
   p = json->source;
   pe = p + json->len;
 
-#line 1955 "parser.c"
+#line 1963 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1985,7 +1993,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 820 "parser.rl"
+#line 828 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -1995,7 +2003,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1999 "parser.c"
+#line 2007 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2084,7 +2092,7 @@ case 9:
 	_out: {}
 	}
 
-#line 848 "parser.rl"
+#line 856 "parser.rl"
 
   if (cs >= JSON_first_final && p == pe) {
     return result;

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1834,78 +1834,78 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
     }
 
     if (!NIL_P(opts)) {
-	VALUE tmp = ID2SYM(i_max_nesting);
-	if (option_given_p(opts, tmp)) {
-	    VALUE max_nesting = rb_hash_aref(opts, tmp);
-	    if (RTEST(max_nesting)) {
-		Check_Type(max_nesting, T_FIXNUM);
-		json->max_nesting = FIX2INT(max_nesting);
-	    } else {
-		json->max_nesting = 0;
-	    }
-	} else {
-	    json->max_nesting = 100;
-	}
-	tmp = ID2SYM(i_allow_nan);
-	if (option_given_p(opts, tmp)) {
-	    json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-	} else {
-	    json->allow_nan = 0;
-	}
-	tmp = ID2SYM(i_symbolize_names);
-	if (option_given_p(opts, tmp)) {
-	    json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-	} else {
-	    json->symbolize_names = 0;
-	}
-	tmp = ID2SYM(i_freeze);
-	if (option_given_p(opts, tmp)) {
-	    json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-	} else {
-	    json->freeze = 0;
-	}
-	tmp = ID2SYM(i_create_additions);
-	if (option_given_p(opts, tmp)) {
-	    json->create_additions = RTEST(rb_hash_aref(opts, tmp));
-	} else {
-	    json->create_additions = 0;
-	}
-	if (json->symbolize_names && json->create_additions) {
-	    rb_raise(rb_eArgError,
-		     "options :symbolize_names and :create_additions cannot be "
-		     " used in conjunction");
-	}
-	tmp = ID2SYM(i_create_id);
-	if (option_given_p(opts, tmp)) {
-	    json->create_id = rb_hash_aref(opts, tmp);
-	} else {
-	    json->create_id = rb_funcall(mJSON, i_create_id, 0);
-	}
-	tmp = ID2SYM(i_object_class);
-	if (option_given_p(opts, tmp)) {
-	    json->object_class = rb_hash_aref(opts, tmp);
-	} else {
-	    json->object_class = Qnil;
-	}
-	tmp = ID2SYM(i_array_class);
-	if (option_given_p(opts, tmp)) {
-	    json->array_class = rb_hash_aref(opts, tmp);
-	} else {
-	    json->array_class = Qnil;
-	}
-	tmp = ID2SYM(i_decimal_class);
-	if (option_given_p(opts, tmp)) {
-	    json->decimal_class = rb_hash_aref(opts, tmp);
-	} else {
-	    json->decimal_class = Qnil;
-	}
-	tmp = ID2SYM(i_match_string);
-	if (option_given_p(opts, tmp)) {
-	    VALUE match_string = rb_hash_aref(opts, tmp);
-	    json->match_string = RTEST(match_string) ? match_string : Qnil;
-	} else {
-	    json->match_string = Qnil;
-	}
+    VALUE tmp = ID2SYM(i_max_nesting);
+    if (option_given_p(opts, tmp)) {
+        VALUE max_nesting = rb_hash_aref(opts, tmp);
+        if (RTEST(max_nesting)) {
+            Check_Type(max_nesting, T_FIXNUM);
+            json->max_nesting = FIX2INT(max_nesting);
+        } else {
+            json->max_nesting = 0;
+        }
+    } else {
+        json->max_nesting = 100;
+    }
+    tmp = ID2SYM(i_allow_nan);
+    if (option_given_p(opts, tmp)) {
+        json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+    } else {
+        json->allow_nan = 0;
+    }
+    tmp = ID2SYM(i_symbolize_names);
+    if (option_given_p(opts, tmp)) {
+        json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+    } else {
+        json->symbolize_names = 0;
+    }
+    tmp = ID2SYM(i_freeze);
+    if (option_given_p(opts, tmp)) {
+        json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+    } else {
+        json->freeze = 0;
+    }
+    tmp = ID2SYM(i_create_additions);
+    if (option_given_p(opts, tmp)) {
+        json->create_additions = RTEST(rb_hash_aref(opts, tmp));
+    } else {
+        json->create_additions = 0;
+    }
+    if (json->symbolize_names && json->create_additions) {
+        rb_raise(rb_eArgError,
+            "options :symbolize_names and :create_additions cannot be "
+            " used in conjunction");
+    }
+    tmp = ID2SYM(i_create_id);
+    if (option_given_p(opts, tmp)) {
+        json->create_id = rb_hash_aref(opts, tmp);
+    } else {
+        json->create_id = rb_funcall(mJSON, i_create_id, 0);
+    }
+    tmp = ID2SYM(i_object_class);
+    if (option_given_p(opts, tmp)) {
+        json->object_class = rb_hash_aref(opts, tmp);
+    } else {
+        json->object_class = Qnil;
+    }
+    tmp = ID2SYM(i_array_class);
+    if (option_given_p(opts, tmp)) {
+        json->array_class = rb_hash_aref(opts, tmp);
+    } else {
+        json->array_class = Qnil;
+    }
+    tmp = ID2SYM(i_decimal_class);
+    if (option_given_p(opts, tmp)) {
+        json->decimal_class = rb_hash_aref(opts, tmp);
+    } else {
+        json->decimal_class = Qnil;
+    }
+    tmp = ID2SYM(i_match_string);
+    if (option_given_p(opts, tmp)) {
+        VALUE match_string = rb_hash_aref(opts, tmp);
+        json->match_string = RTEST(match_string) ? match_string : Qnil;
+    } else {
+        json->match_string = Qnil;
+    }
     } else {
         json->max_nesting = 100;
         json->allow_nan = 0;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -719,7 +719,15 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
     if (json->Vsource) {
         rb_raise(rb_eTypeError, "already initialized instance");
     }
-    rb_scan_args(argc, argv, "1:", &source, &opts);
+
+    rb_check_arity(argc, 1, 2);
+    source = argv[0];
+    opts = Qnil;
+    if (argc == 2) {
+        opts = argv[1];
+        Check_Type(opts, T_HASH);
+    }
+
     if (!NIL_P(opts)) {
 	VALUE tmp = ID2SYM(i_max_nesting);
 	if (option_given_p(opts, tmp)) {

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -729,78 +729,78 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
     }
 
     if (!NIL_P(opts)) {
-	VALUE tmp = ID2SYM(i_max_nesting);
-	if (option_given_p(opts, tmp)) {
-	    VALUE max_nesting = rb_hash_aref(opts, tmp);
-	    if (RTEST(max_nesting)) {
-		Check_Type(max_nesting, T_FIXNUM);
-		json->max_nesting = FIX2INT(max_nesting);
-	    } else {
-		json->max_nesting = 0;
-	    }
-	} else {
-	    json->max_nesting = 100;
-	}
-	tmp = ID2SYM(i_allow_nan);
-	if (option_given_p(opts, tmp)) {
-	    json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-	} else {
-	    json->allow_nan = 0;
-	}
-	tmp = ID2SYM(i_symbolize_names);
-	if (option_given_p(opts, tmp)) {
-	    json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-	} else {
-	    json->symbolize_names = 0;
-	}
-	tmp = ID2SYM(i_freeze);
-	if (option_given_p(opts, tmp)) {
-	    json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-	} else {
-	    json->freeze = 0;
-	}
-	tmp = ID2SYM(i_create_additions);
-	if (option_given_p(opts, tmp)) {
-	    json->create_additions = RTEST(rb_hash_aref(opts, tmp));
-	} else {
-	    json->create_additions = 0;
-	}
-	if (json->symbolize_names && json->create_additions) {
-	    rb_raise(rb_eArgError,
-		     "options :symbolize_names and :create_additions cannot be "
-		     " used in conjunction");
-	}
-	tmp = ID2SYM(i_create_id);
-	if (option_given_p(opts, tmp)) {
-	    json->create_id = rb_hash_aref(opts, tmp);
-	} else {
-	    json->create_id = rb_funcall(mJSON, i_create_id, 0);
-	}
-	tmp = ID2SYM(i_object_class);
-	if (option_given_p(opts, tmp)) {
-	    json->object_class = rb_hash_aref(opts, tmp);
-	} else {
-	    json->object_class = Qnil;
-	}
-	tmp = ID2SYM(i_array_class);
-	if (option_given_p(opts, tmp)) {
-	    json->array_class = rb_hash_aref(opts, tmp);
-	} else {
-	    json->array_class = Qnil;
-	}
-	tmp = ID2SYM(i_decimal_class);
-	if (option_given_p(opts, tmp)) {
-	    json->decimal_class = rb_hash_aref(opts, tmp);
-	} else {
-	    json->decimal_class = Qnil;
-	}
-	tmp = ID2SYM(i_match_string);
-	if (option_given_p(opts, tmp)) {
-	    VALUE match_string = rb_hash_aref(opts, tmp);
-	    json->match_string = RTEST(match_string) ? match_string : Qnil;
-	} else {
-	    json->match_string = Qnil;
-	}
+    VALUE tmp = ID2SYM(i_max_nesting);
+    if (option_given_p(opts, tmp)) {
+        VALUE max_nesting = rb_hash_aref(opts, tmp);
+        if (RTEST(max_nesting)) {
+            Check_Type(max_nesting, T_FIXNUM);
+            json->max_nesting = FIX2INT(max_nesting);
+        } else {
+            json->max_nesting = 0;
+        }
+    } else {
+        json->max_nesting = 100;
+    }
+    tmp = ID2SYM(i_allow_nan);
+    if (option_given_p(opts, tmp)) {
+        json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+    } else {
+        json->allow_nan = 0;
+    }
+    tmp = ID2SYM(i_symbolize_names);
+    if (option_given_p(opts, tmp)) {
+        json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+    } else {
+        json->symbolize_names = 0;
+    }
+    tmp = ID2SYM(i_freeze);
+    if (option_given_p(opts, tmp)) {
+        json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+    } else {
+        json->freeze = 0;
+    }
+    tmp = ID2SYM(i_create_additions);
+    if (option_given_p(opts, tmp)) {
+        json->create_additions = RTEST(rb_hash_aref(opts, tmp));
+    } else {
+        json->create_additions = 0;
+    }
+    if (json->symbolize_names && json->create_additions) {
+        rb_raise(rb_eArgError,
+            "options :symbolize_names and :create_additions cannot be "
+            " used in conjunction");
+    }
+    tmp = ID2SYM(i_create_id);
+    if (option_given_p(opts, tmp)) {
+        json->create_id = rb_hash_aref(opts, tmp);
+    } else {
+        json->create_id = rb_funcall(mJSON, i_create_id, 0);
+    }
+    tmp = ID2SYM(i_object_class);
+    if (option_given_p(opts, tmp)) {
+        json->object_class = rb_hash_aref(opts, tmp);
+    } else {
+        json->object_class = Qnil;
+    }
+    tmp = ID2SYM(i_array_class);
+    if (option_given_p(opts, tmp)) {
+        json->array_class = rb_hash_aref(opts, tmp);
+    } else {
+        json->array_class = Qnil;
+    }
+    tmp = ID2SYM(i_decimal_class);
+    if (option_given_p(opts, tmp)) {
+        json->decimal_class = rb_hash_aref(opts, tmp);
+    } else {
+        json->decimal_class = Qnil;
+    }
+    tmp = ID2SYM(i_match_string);
+    if (option_given_p(opts, tmp)) {
+        VALUE match_string = rb_hash_aref(opts, tmp);
+        json->match_string = RTEST(match_string) ? match_string : Qnil;
+    } else {
+        json->match_string = Qnil;
+    }
     } else {
         json->max_nesting = 100;
         json->allow_nan = 0;

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -221,8 +221,12 @@ module JSON
   #   # Raises JSON::ParserError (783: unexpected token at ''):
   #   JSON.parse('')
   #
-  def parse(source, opts = {})
-    Parser.new(source, **(opts||{})).parse
+  def parse(source, opts = nil)
+    if opts.nil?
+      Parser.new(source).parse
+    else
+      Parser.new(source, opts).parse
+    end
   end
 
   # :call-seq:
@@ -543,15 +547,23 @@ module JSON
   #      #<Admin:0x00000000064c41f8
   #      @attributes={"type"=>"Admin", "password"=>"0wn3d"}>}
   #
-  def load(source, proc = nil, options = {})
-    opts = load_default_options.merge options
-    if source.respond_to? :to_str
-      source = source.to_str
-    elsif source.respond_to? :to_io
-      source = source.to_io.read
-    elsif source.respond_to?(:read)
-      source = source.read
+  def load(source, proc = nil, options = nil)
+    opts = if options.nil?
+      load_default_options
+    else
+      load_default_options.merge(options)
     end
+
+    unless source.is_a?(String)
+      if source.respond_to? :to_str
+        source = source.to_str
+      elsif source.respond_to? :to_io
+        source = source.to_io.read
+      elsif source.respond_to?(:read)
+        source = source.read
+      end
+    end
+
     if opts[:allow_blank] && (source.nil? || source.empty?)
       source = 'null'
     end

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -76,7 +76,7 @@ module JSON
       # * *decimal_class*: Specifies which class to use instead of the default
       #    (Float) when parsing decimal numbers. This class must accept a single
       #    string argument in its constructor.
-      def initialize(source, opts = {})
+      def initialize(source, opts = nil)
         opts ||= {}
         source = convert_encoding source
         super source


### PR DESCRIPTION
Avoid needless hash allocations and such that degrade performance significantly on micro-benchmarks.