### PR TITLE
Limit the size of ParserError exception messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 * Numerous performance optimizations in `JSON.generate` and `JSON.dump`.
+* Limit the size of ParserError exception messages, only include up to 32 bytes of the unparseable source.
 * Fix json-pure's `Object#to_json` to accept non state arguments 
 * Fix multiline comment support in `json-pure`.
 * Fix `JSON.parse` to no longer mutate the argument encoding when passed an ASCII-8BIT string.

--- a/Rakefile
+++ b/Rakefile
@@ -258,7 +258,6 @@ else
     task :compile => [ :ragel, EXT_PARSER_DL, EXT_GENERATOR_DL ]
   end
 
-
   desc "Testing library (extension)"
   task :test_ext => [ :set_env_ext, :check_env, :compile, :do_test_ext ]
   task(:set_env_ext) { ENV['JSON'] = 'ext' }

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -69,7 +69,15 @@ static int convert_UTF32_to_UTF8(char *buf, uint32_t ch)
     return len;
 }
 
-static VALUE mJSON, mExt, cParser, eParserError, eNestingError;
+#ifdef RBIMPL_ATTR_NORETURN
+RBIMPL_ATTR_NORETURN()
+#endif
+static void raise_parse_error(const char *format, const char *start)
+{
+    rb_enc_raise(rb_utf8_encoding(), rb_path2class("JSON::ParserError"), format, start);
+}
+
+static VALUE mJSON, mExt, cParser, eNestingError;
 static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
@@ -83,11 +91,11 @@ static int utf8_encindex;
 
 
 
-#line 109 "parser.rl"
+#line 117 "parser.rl"
 
 
 
-#line 91 "parser.c"
+#line 99 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 27};
 enum {JSON_object_error = 0};
@@ -95,7 +103,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 151 "parser.rl"
+#line 159 "parser.rl"
 
 
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -111,14 +119,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     *result = NIL_P(object_class) ? rb_hash_new() : rb_class_new_instance(0, 0, object_class);
 
 
-#line 115 "parser.c"
+#line 123 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 166 "parser.rl"
+#line 174 "parser.rl"
 
-#line 122 "parser.c"
+#line 130 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -146,7 +154,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 133 "parser.rl"
+#line 141 "parser.rl"
 	{
         char *np;
         json->parsing_name = 1;
@@ -159,7 +167,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 163 "parser.c"
+#line 171 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -226,7 +234,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 117 "parser.rl"
+#line 125 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -247,7 +255,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 251 "parser.c"
+#line 259 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st9;
 		case 32: goto st9;
@@ -336,14 +344,14 @@ case 18:
 		goto st9;
 	goto st18;
 tr4:
-#line 141 "parser.rl"
+#line 149 "parser.rl"
 	{ p--; {p++; cs = 27; goto _out;} }
 	goto st27;
 st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 347 "parser.c"
+#line 355 "parser.c"
 	goto st0;
 st19:
 	if ( ++p == pe )
@@ -441,7 +449,7 @@ case 26:
 	_out: {}
 	}
 
-#line 167 "parser.rl"
+#line 175 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         if (json->create_additions) {
@@ -466,7 +474,7 @@ case 26:
 
 
 
-#line 470 "parser.c"
+#line 478 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -474,7 +482,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 267 "parser.rl"
+#line 275 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -482,14 +490,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 486 "parser.c"
+#line 494 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 274 "parser.rl"
+#line 282 "parser.rl"
 
-#line 493 "parser.c"
+#line 501 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -523,14 +531,14 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 219 "parser.rl"
+#line 227 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) { p--; {p++; cs = 29; goto _out;} } else {p = (( np))-1;}
     }
 	goto st29;
 tr3:
-#line 224 "parser.rl"
+#line 232 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -539,7 +547,7 @@ tr3:
                 {p = (( p + 10))-1;}
                 p--; {p++; cs = 29; goto _out;}
             } else {
-                rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
+                raise_parse_error("unexpected token at '%s'", p);
             }
         }
         np = JSON_parse_float(json, p, pe, result);
@@ -550,7 +558,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 242 "parser.rl"
+#line 250 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -558,7 +566,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 248 "parser.rl"
+#line 256 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -566,39 +574,39 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 212 "parser.rl"
+#line 220 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
         } else {
-            rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p - 7);
+            raise_parse_error("unexpected token at '%s'", p - 7);
         }
     }
 	goto st29;
 tr27:
-#line 205 "parser.rl"
+#line 213 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
         } else {
-            rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p - 2);
+            raise_parse_error("unexpected token at '%s'", p - 2);
         }
     }
 	goto st29;
 tr31:
-#line 199 "parser.rl"
+#line 207 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 196 "parser.rl"
+#line 204 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 202 "parser.rl"
+#line 210 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -607,9 +615,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 254 "parser.rl"
+#line 262 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 613 "parser.c"
+#line 621 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -850,7 +858,7 @@ case 28:
 	_out: {}
 	}
 
-#line 275 "parser.rl"
+#line 283 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -864,7 +872,7 @@ case 28:
 }
 
 
-#line 868 "parser.c"
+#line 876 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -872,7 +880,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 295 "parser.rl"
+#line 303 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -880,15 +888,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 884 "parser.c"
+#line 892 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 302 "parser.rl"
+#line 310 "parser.rl"
     json->memo = p;
 
-#line 892 "parser.c"
+#line 900 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -922,14 +930,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 292 "parser.rl"
+#line 300 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 933 "parser.c"
+#line 941 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -948,7 +956,7 @@ case 5:
 	_out: {}
 	}
 
-#line 304 "parser.rl"
+#line 312 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -963,7 +971,7 @@ case 5:
 }
 
 
-#line 967 "parser.c"
+#line 975 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -971,7 +979,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 329 "parser.rl"
+#line 337 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -979,15 +987,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 983 "parser.c"
+#line 991 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 336 "parser.rl"
+#line 344 "parser.rl"
     json->memo = p;
 
-#line 991 "parser.c"
+#line 999 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1045,14 +1053,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 323 "parser.rl"
+#line 331 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1056 "parser.c"
+#line 1064 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1113,7 +1121,7 @@ case 7:
 	_out: {}
 	}
 
-#line 338 "parser.rl"
+#line 346 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         VALUE mod = Qnil;
@@ -1164,7 +1172,7 @@ case 7:
 
 
 
-#line 1168 "parser.c"
+#line 1176 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 17};
 enum {JSON_array_error = 0};
@@ -1172,7 +1180,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 416 "parser.rl"
+#line 424 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1186,14 +1194,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     *result = NIL_P(array_class) ? rb_ary_new() : rb_class_new_instance(0, 0, array_class);
 
 
-#line 1190 "parser.c"
+#line 1198 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 429 "parser.rl"
+#line 437 "parser.rl"
 
-#line 1197 "parser.c"
+#line 1205 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1232,7 +1240,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 393 "parser.rl"
+#line 401 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1252,7 +1260,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1256 "parser.c"
+#line 1264 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -1352,14 +1360,14 @@ case 12:
 		goto st3;
 	goto st12;
 tr4:
-#line 408 "parser.rl"
+#line 416 "parser.rl"
 	{ p--; {p++; cs = 17; goto _out;} }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1363 "parser.c"
+#line 1371 "parser.c"
 	goto st0;
 st13:
 	if ( ++p == pe )
@@ -1415,12 +1423,12 @@ case 16:
 	_out: {}
 	}
 
-#line 430 "parser.rl"
+#line 438 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         return p + 1;
     } else {
-        rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
+        raise_parse_error("unexpected token at '%s'", p);
         return NULL;
     }
 }
@@ -1483,10 +1491,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                       if (bufferSize > MAX_STACK_BUFFER_SIZE) {
                         ruby_xfree(bufferStart);
                       }
-                      rb_enc_raise(
-                        rb_utf8_encoding(), eParserError,
-                        "incomplete unicode character escape sequence at '%s'", p
-                      );
+                      raise_parse_error("incomplete unicode character escape sequence at '%s'", p);
                     } else {
                         uint32_t ch = unescape_unicode((unsigned char *) ++pe);
                         pe += 3;
@@ -1506,10 +1511,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                               if (bufferSize > MAX_STACK_BUFFER_SIZE) {
                                 ruby_xfree(bufferStart);
                               }
-                              rb_enc_raise(
-                                rb_utf8_encoding(), eParserError,
-                                "incomplete surrogate pair at '%s'", p
-                                );
+                              raise_parse_error("incomplete surrogate pair at '%s'", p);
                             }
                             if (pe[0] == '\\' && pe[1] == 'u') {
                                 uint32_t sur = unescape_unicode((unsigned char *) pe + 2);
@@ -1582,7 +1584,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
 }
 
 
-#line 1586 "parser.c"
+#line 1588 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -1590,7 +1592,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 614 "parser.rl"
+#line 616 "parser.rl"
 
 
 static int
@@ -1611,15 +1613,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 1615 "parser.c"
+#line 1617 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 634 "parser.rl"
+#line 636 "parser.rl"
     json->memo = p;
 
-#line 1623 "parser.c"
+#line 1625 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1644,7 +1646,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 601 "parser.rl"
+#line 603 "parser.rl"
 	{
         *result = json_string_unescape(json->memo + 1, p, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         if (NIL_P(*result)) {
@@ -1654,14 +1656,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 611 "parser.rl"
+#line 613 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1665 "parser.c"
+#line 1667 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -1737,7 +1739,7 @@ case 7:
 	_out: {}
 	}
 
-#line 636 "parser.rl"
+#line 638 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -1924,7 +1926,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1928 "parser.c"
+#line 1930 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1932,7 +1934,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 836 "parser.rl"
+#line 838 "parser.rl"
 
 
 /*
@@ -1944,22 +1946,22 @@ enum {JSON_en_main = 1};
  */
 static VALUE cParser_parse(VALUE self)
 {
-  char *p, *pe;
-  int cs = EVIL;
-  VALUE result = Qnil;
-  GET_PARSER;
+    char *p, *pe;
+    int cs = EVIL;
+    VALUE result = Qnil;
+    GET_PARSER;
 
 
-#line 1954 "parser.c"
+#line 1956 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 853 "parser.rl"
-  p = json->source;
-  pe = p + json->len;
+#line 855 "parser.rl"
+    p = json->source;
+    pe = p + json->len;
 
-#line 1963 "parser.c"
+#line 1965 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1993,7 +1995,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 828 "parser.rl"
+#line 830 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2003,7 +2005,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2007 "parser.c"
+#line 2009 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2092,14 +2094,14 @@ case 9:
 	_out: {}
 	}
 
-#line 856 "parser.rl"
+#line 858 "parser.rl"
 
-  if (cs >= JSON_first_final && p == pe) {
-    return result;
-  } else {
-    rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
-    return Qnil;
-  }
+    if (cs >= JSON_first_final && p == pe) {
+        return result;
+    } else {
+        raise_parse_error("unexpected token at '%s'", p);
+        return Qnil;
+    }
 }
 
 static void JSON_mark(void *ptr)
@@ -2164,9 +2166,7 @@ void Init_parser(void)
     mJSON = rb_define_module("JSON");
     mExt = rb_define_module_under(mJSON, "Ext");
     cParser = rb_define_class_under(mExt, "Parser", rb_cObject);
-    eParserError = rb_path2class("JSON::ParserError");
     eNestingError = rb_path2class("JSON::NestingError");
-    rb_gc_register_mark_object(eParserError);
     rb_gc_register_mark_object(eNestingError);
     rb_define_alloc_func(cParser, cJSON_parser_s_allocate);
     rb_define_method(cParser, "initialize", cParser_initialize, -1);

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -69,12 +69,22 @@ static int convert_UTF32_to_UTF8(char *buf, uint32_t ch)
     return len;
 }
 
+#define PARSE_ERROR_FRAGMENT_LEN 32
 #ifdef RBIMPL_ATTR_NORETURN
 RBIMPL_ATTR_NORETURN()
 #endif
 static void raise_parse_error(const char *format, const char *start)
 {
-    rb_enc_raise(rb_utf8_encoding(), rb_path2class("JSON::ParserError"), format, start);
+    size_t len = strnlen(start, PARSE_ERROR_FRAGMENT_LEN);
+    const char *ptr = start;
+    if (len == PARSE_ERROR_FRAGMENT_LEN) {
+        char buffer[PARSE_ERROR_FRAGMENT_LEN + 1];
+        MEMCPY(buffer, start, char, PARSE_ERROR_FRAGMENT_LEN);
+        buffer[PARSE_ERROR_FRAGMENT_LEN] = '\0';
+        ptr = buffer;
+    }
+
+    rb_enc_raise(rb_utf8_encoding(), rb_path2class("JSON::ParserError"), format, ptr);
 }
 
 static VALUE mJSON, mExt, cParser, eNestingError;
@@ -91,11 +101,11 @@ static int utf8_encindex;
 
 
 
-#line 117 "parser.rl"
+#line 127 "parser.rl"
 
 
 
-#line 99 "parser.c"
+#line 109 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 27};
 enum {JSON_object_error = 0};
@@ -103,7 +113,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 159 "parser.rl"
+#line 169 "parser.rl"
 
 
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -119,14 +129,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     *result = NIL_P(object_class) ? rb_hash_new() : rb_class_new_instance(0, 0, object_class);
 
 
-#line 123 "parser.c"
+#line 133 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 174 "parser.rl"
+#line 184 "parser.rl"
 
-#line 130 "parser.c"
+#line 140 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -154,7 +164,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 141 "parser.rl"
+#line 151 "parser.rl"
 	{
         char *np;
         json->parsing_name = 1;
@@ -167,7 +177,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 171 "parser.c"
+#line 181 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -234,7 +244,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 125 "parser.rl"
+#line 135 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -255,7 +265,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 259 "parser.c"
+#line 269 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st9;
 		case 32: goto st9;
@@ -344,14 +354,14 @@ case 18:
 		goto st9;
 	goto st18;
 tr4:
-#line 149 "parser.rl"
+#line 159 "parser.rl"
 	{ p--; {p++; cs = 27; goto _out;} }
 	goto st27;
 st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 355 "parser.c"
+#line 365 "parser.c"
 	goto st0;
 st19:
 	if ( ++p == pe )
@@ -449,7 +459,7 @@ case 26:
 	_out: {}
 	}
 
-#line 175 "parser.rl"
+#line 185 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         if (json->create_additions) {
@@ -474,7 +484,7 @@ case 26:
 
 
 
-#line 478 "parser.c"
+#line 488 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -482,7 +492,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 275 "parser.rl"
+#line 285 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -490,14 +500,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 494 "parser.c"
+#line 504 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 282 "parser.rl"
+#line 292 "parser.rl"
 
-#line 501 "parser.c"
+#line 511 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -531,14 +541,14 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 227 "parser.rl"
+#line 237 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) { p--; {p++; cs = 29; goto _out;} } else {p = (( np))-1;}
     }
 	goto st29;
 tr3:
-#line 232 "parser.rl"
+#line 242 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -558,7 +568,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 250 "parser.rl"
+#line 260 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -566,7 +576,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 256 "parser.rl"
+#line 266 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -574,7 +584,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 220 "parser.rl"
+#line 230 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -584,7 +594,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 213 "parser.rl"
+#line 223 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -594,19 +604,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 207 "parser.rl"
+#line 217 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 204 "parser.rl"
+#line 214 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 210 "parser.rl"
+#line 220 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -615,9 +625,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 262 "parser.rl"
+#line 272 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 621 "parser.c"
+#line 631 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -858,7 +868,7 @@ case 28:
 	_out: {}
 	}
 
-#line 283 "parser.rl"
+#line 293 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -872,7 +882,7 @@ case 28:
 }
 
 
-#line 876 "parser.c"
+#line 886 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -880,7 +890,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 303 "parser.rl"
+#line 313 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -888,15 +898,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 892 "parser.c"
+#line 902 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 310 "parser.rl"
+#line 320 "parser.rl"
     json->memo = p;
 
-#line 900 "parser.c"
+#line 910 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -930,14 +940,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 300 "parser.rl"
+#line 310 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 941 "parser.c"
+#line 951 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -956,7 +966,7 @@ case 5:
 	_out: {}
 	}
 
-#line 312 "parser.rl"
+#line 322 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -971,7 +981,7 @@ case 5:
 }
 
 
-#line 975 "parser.c"
+#line 985 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -979,7 +989,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 337 "parser.rl"
+#line 347 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -987,15 +997,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 991 "parser.c"
+#line 1001 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 344 "parser.rl"
+#line 354 "parser.rl"
     json->memo = p;
 
-#line 999 "parser.c"
+#line 1009 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1053,14 +1063,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 331 "parser.rl"
+#line 341 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1064 "parser.c"
+#line 1074 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1121,7 +1131,7 @@ case 7:
 	_out: {}
 	}
 
-#line 346 "parser.rl"
+#line 356 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         VALUE mod = Qnil;
@@ -1172,7 +1182,7 @@ case 7:
 
 
 
-#line 1176 "parser.c"
+#line 1186 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 17};
 enum {JSON_array_error = 0};
@@ -1180,7 +1190,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 424 "parser.rl"
+#line 434 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1194,14 +1204,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     *result = NIL_P(array_class) ? rb_ary_new() : rb_class_new_instance(0, 0, array_class);
 
 
-#line 1198 "parser.c"
+#line 1208 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 437 "parser.rl"
+#line 447 "parser.rl"
 
-#line 1205 "parser.c"
+#line 1215 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1240,7 +1250,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 401 "parser.rl"
+#line 411 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1260,7 +1270,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1264 "parser.c"
+#line 1274 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -1360,14 +1370,14 @@ case 12:
 		goto st3;
 	goto st12;
 tr4:
-#line 416 "parser.rl"
+#line 426 "parser.rl"
 	{ p--; {p++; cs = 17; goto _out;} }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1371 "parser.c"
+#line 1381 "parser.c"
 	goto st0;
 st13:
 	if ( ++p == pe )
@@ -1423,7 +1433,7 @@ case 16:
 	_out: {}
 	}
 
-#line 438 "parser.rl"
+#line 448 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         return p + 1;
@@ -1584,7 +1594,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
 }
 
 
-#line 1588 "parser.c"
+#line 1598 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -1592,7 +1602,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 616 "parser.rl"
+#line 626 "parser.rl"
 
 
 static int
@@ -1613,15 +1623,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 1617 "parser.c"
+#line 1627 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 636 "parser.rl"
+#line 646 "parser.rl"
     json->memo = p;
 
-#line 1625 "parser.c"
+#line 1635 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1646,7 +1656,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 603 "parser.rl"
+#line 613 "parser.rl"
 	{
         *result = json_string_unescape(json->memo + 1, p, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         if (NIL_P(*result)) {
@@ -1656,14 +1666,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 613 "parser.rl"
+#line 623 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1667 "parser.c"
+#line 1677 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -1739,7 +1749,7 @@ case 7:
 	_out: {}
 	}
 
-#line 638 "parser.rl"
+#line 648 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -1926,7 +1936,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1930 "parser.c"
+#line 1940 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1934,7 +1944,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 838 "parser.rl"
+#line 848 "parser.rl"
 
 
 /*
@@ -1952,16 +1962,16 @@ static VALUE cParser_parse(VALUE self)
     GET_PARSER;
 
 
-#line 1956 "parser.c"
+#line 1966 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 855 "parser.rl"
+#line 865 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1965 "parser.c"
+#line 1975 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1995,7 +2005,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 830 "parser.rl"
+#line 840 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2005,7 +2015,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2009 "parser.c"
+#line 2019 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2094,7 +2104,7 @@ case 9:
 	_out: {}
 	}
 
-#line 858 "parser.rl"
+#line 868 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -67,12 +67,22 @@ static int convert_UTF32_to_UTF8(char *buf, uint32_t ch)
     return len;
 }
 
+#define PARSE_ERROR_FRAGMENT_LEN 32
 #ifdef RBIMPL_ATTR_NORETURN
 RBIMPL_ATTR_NORETURN()
 #endif
 static void raise_parse_error(const char *format, const char *start)
 {
-    rb_enc_raise(rb_utf8_encoding(), rb_path2class("JSON::ParserError"), format, start);
+    size_t len = strnlen(start, PARSE_ERROR_FRAGMENT_LEN);
+    const char *ptr = start;
+    if (len == PARSE_ERROR_FRAGMENT_LEN) {
+        char buffer[PARSE_ERROR_FRAGMENT_LEN + 1];
+        MEMCPY(buffer, start, char, PARSE_ERROR_FRAGMENT_LEN);
+        buffer[PARSE_ERROR_FRAGMENT_LEN] = '\0';
+        ptr = buffer;
+    }
+
+    rb_enc_raise(rb_utf8_encoding(), rb_path2class("JSON::ParserError"), format, ptr);
 }
 
 static VALUE mJSON, mExt, cParser, eNestingError;

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -332,7 +332,7 @@ public class Parser extends RubyObject {
 
         private RaiseException unexpectedToken(int absStart, int absEnd) {
             RubyString msg = getRuntime().newString("unexpected token at '")
-                    .cat(data, absStart, absEnd - absStart)
+                    .cat(data, absStart, Math.min(absEnd - absStart, 32))
                     .cat((byte)'\'');
             return newException(Utils.M_PARSER_ERROR, msg);
         }

--- a/java/src/json/ext/Parser.rl
+++ b/java/src/json/ext/Parser.rl
@@ -330,7 +330,7 @@ public class Parser extends RubyObject {
 
         private RaiseException unexpectedToken(int absStart, int absEnd) {
             RubyString msg = getRuntime().newString("unexpected token at '")
-                    .cat(data, absStart, absEnd - absStart)
+                    .cat(data, absStart, Math.min(absEnd - absStart, 32))
                     .cat((byte)'\'');
             return newException(Utils.M_PARSER_ERROR, msg);
         }

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -506,6 +506,16 @@ EOT
     )
   end
 
+  def test_parse_error_message_length
+    # Error messages aren't consistent across backends, but we can at least
+    # enforce that if they include fragments of the source it should be of
+    # reasonable size.
+    error = assert_raise(JSON::ParserError) do
+      JSON.parse('{"foo": ' + ('A' * 500) + '}')
+    end
+    assert_operator 60, :>, error.message.bytesize
+  end
+
   private
 
   def string_deduplication_available?


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/534

Only include up to 32 bytes of the unparseable source.