### PR TITLE
pretty_generate: don't apply object_nl / array_nl for empty containers

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -681,6 +681,13 @@ static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
     if (max_nesting != 0 && depth > max_nesting) {
         rb_raise(eNestingError, "nesting of %ld is too deep", --state->depth);
     }
+
+    if (RHASH_SIZE(obj) == 0) {
+        fbuffer_append(buffer, "{}", 2);
+        --state->depth;
+        return;
+    }
+
     fbuffer_append_char(buffer, '{');
 
     arg.buffer = buffer;
@@ -709,6 +716,13 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     if (max_nesting != 0 && depth > max_nesting) {
         rb_raise(eNestingError, "nesting of %ld is too deep", --state->depth);
     }
+
+    if (RARRAY_LEN(obj) == 0) {
+        fbuffer_append(buffer, "[]", 2);
+        --state->depth;
+        return;
+    }
+
     fbuffer_append_char(buffer, '[');
     if (RB_UNLIKELY(state->array_nl)) fbuffer_append(buffer, state->array_nl, state->array_nl_len);
     for(i = 0; i < RARRAY_LEN(obj); i++) {

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -269,6 +269,12 @@ public final class Generator {
                 GeneratorState state = session.getState();
                 int depth = state.increaseDepth();
 
+                if (object.isEmpty()) {
+                    buffer.append("[]".getBytes());
+                    state.decreaseDepth();
+                    return;
+                }
+
                 ByteList indentUnit = state.getIndent();
                 byte[] shift = Utils.repeat(indentUnit, depth);
 
@@ -326,6 +332,12 @@ public final class Generator {
                 final Ruby runtime = context.getRuntime();
                 final GeneratorState state = session.getState();
                 final int depth = state.increaseDepth();
+
+                if (object.isEmpty()) {
+                    buffer.append("{}".getBytes());
+                    state.decreaseDepth();
+                    return;
+                }
 
                 final ByteList objectNl = state.getObjectNl();
                 final byte[] indent = Utils.repeat(state.getIndent(), depth);

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -399,9 +399,15 @@ module JSON
           end
 
           def json_transform(state)
+            depth = state.depth += 1
+
+            if empty?
+              state.depth -= 1
+              return '{}'
+            end
+
             delim = ",#{state.object_nl}"
             result = +"{#{state.object_nl}"
-            depth = state.depth += 1
             first = true
             indent = !state.object_nl.empty?
             each { |key, value|
@@ -441,6 +447,13 @@ module JSON
           private
 
           def json_transform(state)
+            depth = state.depth += 1
+
+            if empty?
+              state.depth -= 1
+              return '[]'
+            end
+
             result = '['.dup
             if state.array_nl.empty?
               delim = ","
@@ -448,7 +461,7 @@ module JSON
               result << state.array_nl
               delim = ",#{state.array_nl}"
             end
-            depth = state.depth += 1
+
             first = true
             indent = !state.array_nl.empty?
             each { |value|

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -90,10 +90,17 @@ EOT
 
   def test_generate_pretty
     json = pretty_generate({})
+    assert_equal('{}', json)
+
+    json = pretty_generate({1=>{}, 2=>[], 3=>4})
     assert_equal(<<'EOT'.chomp, json)
 {
+  "1": {},
+  "2": [],
+  "3": 4
 }
 EOT
+
     json = pretty_generate(@hash)
     # hashes aren't (insertion) ordered on every ruby implementation
     # assert_equal(@json3, json)


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/437

Before:

```json
{
  "foo": {
  },
  "bar": [
  ]
}
```

After:

```json
{
  "foo": {},
  "bar": []
}
```

NB: I'd rather hold on merging this until `2.7.3` has been released, as I'd like to first do a pure fixes and performance release. This can make it into 2.8.0.