### PR TITLE
Raise the correct exception in fast_serialize_string

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1794,6 +1794,9 @@ static VALUE convert_encoding(VALUE source)
   }
 
  if (encindex == binary_encindex) {
+    // For historical reason, we silently reinterpret binary strings as UTF-8 if it would work.
+    // TODO: Deprecate in 2.8.0
+    // TODO: Remove in 3.0.0
     return rb_enc_associate_index(rb_str_dup(source), utf8_encindex);
   }
 
@@ -1943,7 +1946,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1947 "parser.c"
+#line 1950 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1951,7 +1954,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 855 "parser.rl"
+#line 858 "parser.rl"
 
 
 /*
@@ -1969,16 +1972,16 @@ static VALUE cParser_parse(VALUE self)
     GET_PARSER;
 
 
-#line 1973 "parser.c"
+#line 1976 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 872 "parser.rl"
+#line 875 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1982 "parser.c"
+#line 1985 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2012,7 +2015,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 847 "parser.rl"
+#line 850 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2022,7 +2025,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2026 "parser.c"
+#line 2029 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2111,7 +2114,7 @@ case 9:
 	_out: {}
 	}
 
-#line 875 "parser.rl"
+#line 878 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -689,6 +689,9 @@ static VALUE convert_encoding(VALUE source)
   }
 
  if (encindex == binary_encindex) {
+    // For historical reason, we silently reinterpret binary strings as UTF-8 if it would work.
+    // TODO: Deprecate in 2.8.0
+    // TODO: Remove in 3.0.0
     return rb_enc_associate_index(rb_str_dup(source), utf8_encindex);
   }
 

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -339,6 +339,7 @@ module JSON
           private def fast_serialize_string(string, buf) # :nodoc:
             buf << '"'
             string = string.encode(::Encoding::UTF_8) unless string.encoding == ::Encoding::UTF_8
+            raise GeneratorError, "source sequence is illegal/malformed utf-8" unless string.valid_encoding?
 
             if /["\\\x0-\x1f]/n.match?(string)
               buf << string.gsub(/["\\\x0-\x1f]/n, MAP)

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -449,16 +449,12 @@ EOT
     end
     assert_includes error.message, "source sequence is illegal/malformed utf-8"
 
-    # These pass on the pure-Ruby generator but not with the native extension
-    # https://github.com/ruby/json/issues/634
-    if defined?(JSON::Pure)
-      assert_raise(Encoding::UndefinedConversionError) do
-        "\x82\xAC\xEF".b.to_json
-      end
+    assert_raise(Encoding::UndefinedConversionError) do
+      "\x82\xAC\xEF".b.to_json
+    end
 
-      assert_raise(Encoding::UndefinedConversionError) do
-        JSON.dump("\x82\xAC\xEF".b)
-      end
+    assert_raise(Encoding::UndefinedConversionError) do
+      JSON.dump("\x82\xAC\xEF".b)
     end
   end
 

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -443,6 +443,23 @@ EOT
       "\x82\xAC\xEF".to_json
     end
     assert_includes error.message, "source sequence is illegal/malformed utf-8"
+
+    error = assert_raise(JSON::GeneratorError) do
+      JSON.dump("\x82\xAC\xEF")
+    end
+    assert_includes error.message, "source sequence is illegal/malformed utf-8"
+
+    # These pass on the pure-Ruby generator but not with the native extension
+    # https://github.com/ruby/json/issues/634
+    if defined?(JSON::Pure)
+      assert_raise(Encoding::UndefinedConversionError) do
+        "\x82\xAC\xEF".b.to_json
+      end
+
+      assert_raise(Encoding::UndefinedConversionError) do
+        JSON.dump("\x82\xAC\xEF".b)
+      end
+    end
   end
 
   if defined?(JSON::Ext::Generator) and RUBY_PLATFORM != "java"


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/634

* Related to https://github.com/ruby/json/issues/344