### PR TITLE
Add lib/json/ext/generator/state.rb to the gemspec

### DIFF
--- a/json.gemspec
+++ b/json.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
     "lib/json/add/time.rb",
     "lib/json/common.rb",
     "lib/json/ext.rb",
+    "lib/json/ext/generator/state.rb",
     "lib/json/generic_object.rb",
     "lib/json/pure.rb",
     "lib/json/pure/generator.rb",


### PR DESCRIPTION
* Otherwise the gem always uses the pure-Ruby backend as it's missing that file and rescuing the LoadError.

It'd be great to have some tests with the installed gem or so, but I don't have time to add that (at least not now).