### PR TITLE
json_pure: fix ractor compatibility

### DIFF
--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -148,24 +148,24 @@ module JSON
       end
 
       # Unescape characters in strings.
-      UNESCAPE_MAP = Hash.new { |h, k| h[k] = k.chr }
-      UNESCAPE_MAP.update({
-        ?"  => '"',
-        ?\\ => '\\',
-        ?/  => '/',
-        ?b  => "\b",
-        ?f  => "\f",
-        ?n  => "\n",
-        ?r  => "\r",
-        ?t  => "\t",
-        ?u  => nil,
-      })
+      UNESCAPE_MAP = {
+        '"'  => '"',
+        '\\' => '\\',
+        '/'  => '/',
+        'b'  => "\b",
+        'f'  => "\f",
+        'n'  => "\n",
+        'r'  => "\r",
+        't'  => "\t",
+        'u'  => nil,
+      }.freeze
 
       def parse_string
         if scan(STRING)
           return '' if self[1].empty?
           string = self[1].gsub(%r{(?:\\[\\bfnrt"/]|(?:\\u(?:[A-Fa-f\d]{4}))+|\\[\x20-\xff])}n) do |c|
-            if u = UNESCAPE_MAP[$&[1]]
+            k = $&[1]
+            if u = UNESCAPE_MAP.fetch(k) { k.chr }
               u
             else # \uXXXX
               bytes = ''.b

--- a/test/json/ractor_test.rb
+++ b/test/json/ractor_test.rb
@@ -9,10 +9,7 @@ end
 
 class JSONInRactorTest < Test::Unit::TestCase
   def test_generate
-    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
-    begin;
-      $VERBOSE = nil
-      require "json"
+    pid = fork do
       r = Ractor.new do
         json = JSON.generate({
           'a' => 2,
@@ -26,9 +23,22 @@ class JSONInRactorTest < Test::Unit::TestCase
         })
         JSON.parse(json)
       end
-      expected_json = '{"a":2,"b":3.141,"c":"c","d":[1,"b",3.14],"e":{"foo":"bar"},' +
-                      '"g":"\\"\\u0000\\u001f","h":1000.0,"i":0.001}'
-      assert_equal(JSON.parse(expected_json), r.take)
-    end;
+      expected_json = JSON.parse('{"a":2,"b":3.141,"c":"c","d":[1,"b",3.14],"e":{"foo":"bar"},' +
+                      '"g":"\\"\\u0000\\u001f","h":1000.0,"i":0.001}')
+      actual_json = r.take
+
+      if expected_json == actual_json
+        exit 0
+      else
+        puts "Expected:"
+        puts expected_json
+        puts "Acutual:"
+        puts actual_json
+        puts
+        exit 1
+      end
+    end
+    _, status = Process.waitpid2(pid)
+    assert_predicate status, :success?
   end
-end if defined?(Ractor)
+end if defined?(Ractor) && Process.respond_to?(:fork)


### PR DESCRIPTION
This actually never worked, because the test was always testing the ext version from the stdlib, never the pure version nor the current ext version.