### PR TITLE
Instantiate Parser with a kwsplat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Workaround another issue caused by conflicting versions of both `json_pure` and `json` being loaded.
+
 ### 2024-10-25 (2.7.4)
 
 * Workaround a bug in 3.4.8 and older https://github.com/rubygems/rubygems/pull/6490.

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -219,7 +219,12 @@ module JSON
     if opts.nil?
       Parser.new(source).parse
     else
-      Parser.new(source, opts).parse
+      # NB: The ** shouldn't be required, but we have to deal with
+      # different versions of the `json` and `json_pure` gems being
+      # loaded concurrently.
+      # Prior to 2.7.3, `JSON::Ext::Parser` would only take kwargs.
+      # Ref: https://github.com/ruby/json/issues/650
+      Parser.new(source, **opts).parse
     end
   end
 


### PR DESCRIPTION
Prior to 2.7.3, `JSON::Ext::Parser` would only take kwargs. So if json_pure 2.7.4 is loaded with `json <= 2.7.2` (or stdlib) it blows up.

Ref: https://github.com/ruby/json/issues/650
Fix: https://github.com/ruby/json/issues/651

cc @Hohlen 

NB: make sure this doesn't throw warnings in 2.7 or older.