### PR TITLE
Handle all formatting configs potentially being `nil`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Changes
 
+* Gracefully handle formatting configs being set to `nil` instead of `""`.
 * Workaround another issue caused by conflicting versions of both `json_pure` and `json` being loaded.
 
 ### 2024-10-25 (2.7.4)

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -46,15 +46,15 @@ module JSON
           opts.each do |key, value|
             case key
             when :indent
-              self.indent = value
+              self.indent = value || ''
             when :space
-              self.space = value
+              self.space = value || ''
             when :space_before
-              self.space_before = value
+              self.space_before = value || ''
             when :array_nl
-              self.array_nl = value
+              self.array_nl = value || ''
             when :object_nl
-              self.object_nl = value
+              self.object_nl = value || ''
             when :max_nesting
               self.max_nesting = value || 0
             when :depth

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -239,13 +239,13 @@ module JSON
           end
 
           # NOTE: If adding new instance variables here, check whether #generate should check them for #generate_json
-          @indent                = opts[:indent] if opts.key?(:indent)
-          @space                 = opts[:space] if opts.key?(:space)
-          @space_before          = opts[:space_before] if opts.key?(:space_before)
-          @object_nl             = opts[:object_nl] if opts.key?(:object_nl)
-          @array_nl              = opts[:array_nl] if opts.key?(:array_nl)
-          @allow_nan             = !!opts[:allow_nan] if opts.key?(:allow_nan)
-          @ascii_only            = opts[:ascii_only] if opts.key?(:ascii_only)
+          @indent                = opts[:indent]        || '' if opts.key?(:indent)
+          @space                 = opts[:space]         || '' if opts.key?(:space)
+          @space_before          = opts[:space_before]  || '' if opts.key?(:space_before)
+          @object_nl             = opts[:object_nl]     || '' if opts.key?(:object_nl)
+          @array_nl              = opts[:array_nl]      || '' if opts.key?(:array_nl)
+          @allow_nan             = !!opts[:allow_nan]         if opts.key?(:allow_nan)
+          @ascii_only            = opts[:ascii_only]          if opts.key?(:ascii_only)
           @depth                 = opts[:depth] || 0
           @buffer_initial_length ||= opts[:buffer_initial_length]
 

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -167,6 +167,27 @@ EOT
     assert s[:check_circular?]
   end
 
+  def test_falsy_state
+    object = { foo: [1, 2], bar: { egg: :spam }}
+    expected_json = JSON.generate(
+      object,
+      array_nl:     "",
+      indent:       "",
+      object_nl:    "",
+      space:        "",
+      space_before: "",
+    )
+
+    assert_equal expected_json, JSON.generate(
+      object,
+      array_nl:     nil,
+      indent:       nil,
+      object_nl:    nil,
+      space:        nil,
+      space_before: nil,
+    )
+  end
+
   def test_pretty_state
     state = JSON.create_pretty_state
     assert_equal({


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/653

I don't think this was really fully supported in the past, but it kinda worked with some of the implementations.