### PR TITLE
Allocate the FBuffer struct on the stack

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -13,12 +13,11 @@ typedef struct FBufferStruct {
 
 #define FBUFFER_INITIAL_LENGTH_DEFAULT 1024
 
-#define FBUFFER_PTR(fb) (fb->ptr)
-#define FBUFFER_LEN(fb) (fb->len)
-#define FBUFFER_CAPA(fb) (fb->capa)
+#define FBUFFER_PTR(fb) ((fb)->ptr)
+#define FBUFFER_LEN(fb) ((fb)->len)
+#define FBUFFER_CAPA(fb) ((fb)->capa)
 #define FBUFFER_PAIR(fb) FBUFFER_PTR(fb), FBUFFER_LEN(fb)
 
-static FBuffer *fbuffer_alloc(unsigned long initial_length);
 static void fbuffer_free(FBuffer *fb);
 #ifndef JSON_GENERATOR
 static void fbuffer_clear(FBuffer *fb);
@@ -36,20 +35,14 @@ static VALUE fbuffer_to_s(FBuffer *fb);
 #define RB_UNLIKELY(expr) expr
 #endif
 
-static FBuffer *fbuffer_alloc(unsigned long initial_length)
+static void fbuffer_init(FBuffer *fb, unsigned long initial_length)
 {
-    FBuffer *fb;
-    if (initial_length <= 0) initial_length = FBUFFER_INITIAL_LENGTH_DEFAULT;
-    fb = ALLOC(FBuffer);
-    memset((void *) fb, 0, sizeof(FBuffer));
-    fb->initial_length = initial_length;
-    return fb;
+    fb->initial_length = (initial_length > 0) ? initial_length : FBUFFER_INITIAL_LENGTH_DEFAULT;
 }
 
 static void fbuffer_free(FBuffer *fb)
 {
     if (fb->ptr) ruby_xfree(fb->ptr);
-    ruby_xfree(fb);
 }
 
 #ifndef JSON_GENERATOR

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -911,15 +911,6 @@ static void generate_json(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *s
     }
 }
 
-static FBuffer *cState_prepare_buffer(VALUE self)
-{
-    FBuffer *buffer;
-    GET_STATE(self);
-    buffer = fbuffer_alloc(state->buffer_initial_length);
-
-    return buffer;
-}
-
 struct generate_json_data {
     FBuffer *buffer;
     VALUE vstate;
@@ -948,18 +939,20 @@ static VALUE generate_json_rescue(VALUE d, VALUE exc)
 
 static VALUE cState_partial_generate(VALUE self, VALUE obj)
 {
-    FBuffer *buffer = cState_prepare_buffer(self);
     GET_STATE(self);
 
+    FBuffer buffer = {0};
+    fbuffer_init(&buffer, state->buffer_initial_length);
+
     struct generate_json_data data = {
-        .buffer = buffer,
+        .buffer = &buffer,
         .vstate = self,
         .state = state,
         .obj = obj
     };
     rb_rescue(generate_json_try, (VALUE)&data, generate_json_rescue, (VALUE)&data);
 
-    return fbuffer_to_s(buffer);
+    return fbuffer_to_s(&buffer);
 }
 
 /*

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -55,16 +55,16 @@ typedef struct JSON_Generator_StateStruct {
     GET_STATE_TO(self, state)
 
 #define GENERATE_JSON(type)                                                                     \
-    FBuffer *buffer;                                                                            \
     VALUE Vstate;                                                                               \
     JSON_Generator_State *state;                                                                \
                                                                                                 \
     rb_scan_args(argc, argv, "01", &Vstate);                                                    \
     Vstate = cState_from_state_s(cState, Vstate);                                               \
     TypedData_Get_Struct(Vstate, JSON_Generator_State, &JSON_Generator_State_type, state);      \
-    buffer = cState_prepare_buffer(Vstate);                                                     \
-    generate_json_##type(buffer, Vstate, state, self);                                          \
-    return fbuffer_to_s(buffer)
+    FBuffer buffer = {0};                                                                       \
+    fbuffer_init(&buffer, state->buffer_initial_length);                                        \
+    generate_json_##type(&buffer, Vstate, state, self);                                         \
+    return fbuffer_to_s(&buffer)
 
 static VALUE mHash_to_json(int argc, VALUE *argv, VALUE self);
 static VALUE mArray_to_json(int argc, VALUE *argv, VALUE self);
@@ -122,7 +122,6 @@ static VALUE cState_script_safe(VALUE self);
 static VALUE cState_script_safe_set(VALUE self, VALUE depth);
 static VALUE cState_strict(VALUE self);
 static VALUE cState_strict_set(VALUE self, VALUE strict);
-static FBuffer *cState_prepare_buffer(VALUE self);
 
 static const rb_data_type_t JSON_Generator_State_type;
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -972,10 +972,10 @@ case 5:
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
-        fbuffer_clear(json->fbuffer);
-        fbuffer_append(json->fbuffer, json->memo, len);
-        fbuffer_append_char(json->fbuffer, '\0');
-        *result = rb_cstr2inum(FBUFFER_PTR(json->fbuffer), 10);
+        fbuffer_clear(&json->fbuffer);
+        fbuffer_append(&json->fbuffer, json->memo, len);
+        fbuffer_append_char(&json->fbuffer, '\0');
+        *result = rb_cstr2inum(FBUFFER_PTR(&json->fbuffer), 10);
         return p + 1;
     } else {
         return NULL;
@@ -1167,15 +1167,15 @@ case 7:
         }
 
         long len = p - json->memo;
-        fbuffer_clear(json->fbuffer);
-        fbuffer_append(json->fbuffer, json->memo, len);
-        fbuffer_append_char(json->fbuffer, '\0');
+        fbuffer_clear(&json->fbuffer);
+        fbuffer_append(&json->fbuffer, json->memo, len);
+        fbuffer_append_char(&json->fbuffer, '\0');
 
         if (method_id) {
-            VALUE text = rb_str_new2(FBUFFER_PTR(json->fbuffer));
+            VALUE text = rb_str_new2(FBUFFER_PTR(&json->fbuffer));
             *result = rb_funcallv(mod, method_id, 1, &text);
         } else {
-            *result = DBL2NUM(rb_cstr_to_dbl(FBUFFER_PTR(json->fbuffer), 1));
+            *result = DBL2NUM(rb_cstr_to_dbl(FBUFFER_PTR(&json->fbuffer), 1));
         }
 
         return p + 1;
@@ -2138,14 +2138,14 @@ static void JSON_mark(void *ptr)
 static void JSON_free(void *ptr)
 {
     JSON_Parser *json = ptr;
-    fbuffer_free(json->fbuffer);
+    fbuffer_free(&json->fbuffer);
     ruby_xfree(json);
 }
 
 static size_t JSON_memsize(const void *ptr)
 {
     const JSON_Parser *json = ptr;
-    return sizeof(*json) + FBUFFER_CAPA(json->fbuffer);
+    return sizeof(*json) + FBUFFER_CAPA(&json->fbuffer);
 }
 
 static const rb_data_type_t JSON_Parser_type = {
@@ -2159,7 +2159,7 @@ static VALUE cJSON_parser_s_allocate(VALUE klass)
 {
     JSON_Parser *json;
     VALUE obj = TypedData_Make_Struct(klass, JSON_Parser, &JSON_Parser_type, json);
-    json->fbuffer = fbuffer_alloc(0);
+    fbuffer_init(&json->fbuffer, 0);
     return obj;
 }
 

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -19,7 +19,7 @@ typedef struct JSON_ParserStruct {
     VALUE array_class;
     VALUE decimal_class;
     VALUE match_string;
-    FBuffer *fbuffer;
+    FBuffer fbuffer;
     int max_nesting;
     char allow_nan;
     char parsing_name;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -324,10 +324,10 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
-        fbuffer_clear(json->fbuffer);
-        fbuffer_append(json->fbuffer, json->memo, len);
-        fbuffer_append_char(json->fbuffer, '\0');
-        *result = rb_cstr2inum(FBUFFER_PTR(json->fbuffer), 10);
+        fbuffer_clear(&json->fbuffer);
+        fbuffer_append(&json->fbuffer, json->memo, len);
+        fbuffer_append_char(&json->fbuffer, '\0');
+        *result = rb_cstr2inum(FBUFFER_PTR(&json->fbuffer), 10);
         return p + 1;
     } else {
         return NULL;
@@ -388,15 +388,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
         }
 
         long len = p - json->memo;
-        fbuffer_clear(json->fbuffer);
-        fbuffer_append(json->fbuffer, json->memo, len);
-        fbuffer_append_char(json->fbuffer, '\0');
+        fbuffer_clear(&json->fbuffer);
+        fbuffer_append(&json->fbuffer, json->memo, len);
+        fbuffer_append_char(&json->fbuffer, '\0');
 
         if (method_id) {
-            VALUE text = rb_str_new2(FBUFFER_PTR(json->fbuffer));
+            VALUE text = rb_str_new2(FBUFFER_PTR(&json->fbuffer));
             *result = rb_funcallv(mod, method_id, 1, &text);
         } else {
-            *result = DBL2NUM(rb_cstr_to_dbl(FBUFFER_PTR(json->fbuffer), 1));
+            *result = DBL2NUM(rb_cstr_to_dbl(FBUFFER_PTR(&json->fbuffer), 1));
         }
 
         return p + 1;
@@ -898,14 +898,14 @@ static void JSON_mark(void *ptr)
 static void JSON_free(void *ptr)
 {
     JSON_Parser *json = ptr;
-    fbuffer_free(json->fbuffer);
+    fbuffer_free(&json->fbuffer);
     ruby_xfree(json);
 }
 
 static size_t JSON_memsize(const void *ptr)
 {
     const JSON_Parser *json = ptr;
-    return sizeof(*json) + FBUFFER_CAPA(json->fbuffer);
+    return sizeof(*json) + FBUFFER_CAPA(&json->fbuffer);
 }
 
 static const rb_data_type_t JSON_Parser_type = {
@@ -919,7 +919,7 @@ static VALUE cJSON_parser_s_allocate(VALUE klass)
 {
     JSON_Parser *json;
     VALUE obj = TypedData_Make_Struct(klass, JSON_Parser, &JSON_Parser_type, json);
-    json->fbuffer = fbuffer_alloc(0);
+    fbuffer_init(&json->fbuffer, 0);
     return obj;
 }
 


### PR DESCRIPTION
Ref: https://github.com/ruby/json/issues/655

The actual buffer is still on the heap, but this saves a pair of malloc/free.

This helps a lot on micro-benchmarks

Before:

```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                  Oj   531.598k i/100ms
          JSON reuse   417.666k i/100ms
Calculating -------------------------------------
                  Oj      5.735M (± 1.3%) i/s  (174.35 ns/i) -     28.706M in   5.005900s
          JSON reuse      4.604M (± 1.4%) i/s  (217.18 ns/i) -     23.389M in   5.080779s

Comparison:
                  Oj:  5735475.6 i/s
          JSON reuse:  4604380.3 i/s - 1.25x  slower
```

After:

```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                  Oj   518.700k i/100ms
          JSON reuse   483.370k i/100ms
Calculating -------------------------------------
                  Oj      5.722M (± 1.8%) i/s  (174.76 ns/i) -     29.047M in   5.077823s
          JSON reuse      5.278M (± 1.5%) i/s  (189.46 ns/i) -     26.585M in   5.038172s

Comparison:
                  Oj:  5722283.8 i/s
          JSON reuse:  5278061.7 i/s - 1.08x  slower
```

Bench:

```ruby
require 'benchmark/ips'
require 'oj'
require 'json'

json_encoder = JSON::State.new(JSON.dump_default_options)
test_data = [1, "string", { a: 1, b: 2 }, [3, 4, 5]]

Oj.default_options = Oj.default_options.merge(mode: :compat)

Benchmark.ips do |x|
  x.config(time: 5, warmup: 2)

  x.report("Oj") do
    Oj.dump(test_data)
  end

  x.report("JSON reuse") do
    json_encoder.generate(test_data)
  end

  x.compare!(order: :baseline)
end
```