### PR TITLE
Fix a memory leak in #to_json methods

### DIFF
--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -54,18 +54,6 @@ typedef struct JSON_Generator_StateStruct {
     JSON_Generator_State *state;              \
     GET_STATE_TO(self, state)
 
-#define GENERATE_JSON(type)                                                                     \
-    VALUE Vstate;                                                                               \
-    JSON_Generator_State *state;                                                                \
-                                                                                                \
-    rb_scan_args(argc, argv, "01", &Vstate);                                                    \
-    Vstate = cState_from_state_s(cState, Vstate);                                               \
-    TypedData_Get_Struct(Vstate, JSON_Generator_State, &JSON_Generator_State_type, state);      \
-    FBuffer buffer = {0};                                                                       \
-    fbuffer_init(&buffer, state->buffer_initial_length);                                        \
-    generate_json_##type(&buffer, Vstate, state, self);                                         \
-    return fbuffer_to_s(&buffer)
-
 static VALUE mHash_to_json(int argc, VALUE *argv, VALUE self);
 static VALUE mArray_to_json(int argc, VALUE *argv, VALUE self);
 #ifdef RUBY_INTEGER_UNIFICATION
@@ -99,7 +87,7 @@ static void generate_json_integer(FBuffer *buffer, VALUE Vstate, JSON_Generator_
 static void generate_json_fixnum(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static void generate_json_bignum(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static void generate_json_float(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
-static VALUE cState_partial_generate(VALUE self, VALUE obj);
+static VALUE cState_partial_generate(VALUE self, VALUE obj, void (*func)(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj));
 static VALUE cState_generate(VALUE self, VALUE obj);
 static VALUE cState_from_state_s(VALUE self, VALUE opts);
 static VALUE cState_indent(VALUE self);


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/460

The various `to_json` methods must rescue exceptions to free the buffer.

```
require 'json'

data = 10_000.times.to_a << BasicObject.new
20.times do
  100.times do
    begin
      data.to_json
    rescue NoMethodError
    end
  end
  puts `ps -o rss= -p #{$$}`
end
```

```
 20128
 24992
 29920
 34672
 39600
 44336
 49136
 53936
 58816
 63616
 68416
 73232
 78032
 82896
 87696
 92528
 97408
102208
107008
111808
```