### PR TITLE
Skip calling configure if there are no options

### DIFF
--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -142,10 +142,12 @@ module JSON
           @array_nl              = ''
           @allow_nan             = false
           @ascii_only            = false
-          @script_safe          = false
-          @strict                = false
+          @depth                 = 0
           @buffer_initial_length = 1024
-          configure(opts || {})
+          @script_safe           = false
+          @strict                = false
+          @max_nesting           = 100
+          configure(opts) if opts
         end
 
         # This string is used to indent levels in the JSON text.


### PR DESCRIPTION
* Set all defaults in the constructor.
* Order the instance variables in the same order as in #configure.

Unfortunately because of `JSON.dump_default_options` this fast path won't apply for `JSON.dump`.
I wish those values (`max_nesting: false, allow_nan: true`) would be the default for all generate/dump-like methods and then they could be default in the State constructor.