### PR TITLE
Elude parser allocation

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -169,9 +169,9 @@ tr2:
 #line 153 "parser.rl"
 	{
         char *np;
-        json->parsing_name = 1;
+        json->parsing_name = true;
         np = JSON_parse_string(json, p, pe, &last_name);
-        json->parsing_name = 0;
+        json->parsing_name = false;
         if (np == NULL) { p--; {p++; cs = 3; goto _out;} } else {p = (( np))-1;}
     }
 	goto st3;
@@ -1816,29 +1816,29 @@ static void parser_init(JSON_Parser *json, VALUE source, VALUE opts)
             if (option_given_p(opts, tmp)) {
                 json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
             } else {
-                json->allow_nan = 0;
+                json->allow_nan = false;
             }
             tmp = ID2SYM(i_symbolize_names);
             if (option_given_p(opts, tmp)) {
                 json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
             } else {
-                json->symbolize_names = 0;
+                json->symbolize_names = false;
             }
             tmp = ID2SYM(i_freeze);
             if (option_given_p(opts, tmp)) {
                 json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
             } else {
-                json->freeze = 0;
+                json->freeze = false;
             }
             tmp = ID2SYM(i_create_additions);
             if (option_given_p(opts, tmp)) {
                 tmp = rb_hash_aref(opts, tmp);
                 if (NIL_P(tmp)) {
-                    json->create_additions = 1;
-                    json->deprecated_create_additions = 1;
+                    json->create_additions = true;
+                    json->deprecated_create_additions = true;
                 } else {
                     json->create_additions = RTEST(tmp);
-                    json->deprecated_create_additions = 0;
+                    json->deprecated_create_additions = false;
                 }
             }
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1919,17 +1919,20 @@ static VALUE cParser_parse(VALUE self)
     VALUE result = Qnil;
     GET_PARSER;
 
+    char stack_buffer[FBUFFER_STACK_SIZE];
+    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
 
-#line 1924 "parser.c"
+
+#line 1927 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 823 "parser.rl"
+#line 826 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1933 "parser.c"
+#line 1936 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1973,7 +1976,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1977 "parser.c"
+#line 1980 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2062,7 +2065,7 @@ case 9:
 	_out: {}
 	}
 
-#line 826 "parser.rl"
+#line 829 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;
@@ -2082,17 +2085,20 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     JSON_Parser *json = &parser;
     parser_init(json, source, opts);
 
+    char stack_buffer[FBUFFER_STACK_SIZE];
+    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
 
-#line 2087 "parser.c"
+
+#line 2093 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 846 "parser.rl"
+#line 852 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2096 "parser.c"
+#line 2102 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2136,7 +2142,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2140 "parser.c"
+#line 2146 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2225,7 +2231,7 @@ case 9:
 	_out: {}
 	}
 
-#line 849 "parser.rl"
+#line 855 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -92,22 +92,24 @@ static void raise_parse_error(const char *format, const char *start)
 static VALUE mJSON, mExt, cParser, eNestingError, Encoding_UTF_8;
 static VALUE CNaN, CInfinity, CMinusInfinity;
 
-static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
-          i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
-          i_object_class, i_array_class, i_decimal_class,
-          i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
-          i_leftshift, i_new, i_try_convert, i_freeze, i_uminus, i_encode;
+static ID i_json_creatable_p, i_json_create, i_create_id,
+          i_chr, i_deep_const_get, i_match, i_aset, i_aref,
+          i_leftshift, i_new, i_try_convert, i_uminus, i_encode;
+
+static VALUE sym_max_nesting, sym_allow_nan, sym_symbolize_names, sym_freeze,
+             sym_create_additions, sym_create_id, sym_object_class, sym_array_class,
+             sym_decimal_class, sym_match_string;
 
 static int binary_encindex;
 static int utf8_encindex;
 
 
 
-#line 129 "parser.rl"
+#line 131 "parser.rl"
 
 
 
-#line 111 "parser.c"
+#line 113 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 27};
 enum {JSON_object_error = 0};
@@ -115,7 +117,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 171 "parser.rl"
+#line 173 "parser.rl"
 
 
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -131,14 +133,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     *result = object_class ?  rb_class_new_instance(0, 0, object_class) :rb_hash_new();
 
 
-#line 135 "parser.c"
+#line 137 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 186 "parser.rl"
+#line 188 "parser.rl"
 
-#line 142 "parser.c"
+#line 144 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -166,7 +168,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 153 "parser.rl"
+#line 155 "parser.rl"
 	{
         char *np;
         json->parsing_name = true;
@@ -179,7 +181,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 183 "parser.c"
+#line 185 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -246,7 +248,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 137 "parser.rl"
+#line 139 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -267,7 +269,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 271 "parser.c"
+#line 273 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st9;
 		case 32: goto st9;
@@ -356,14 +358,14 @@ case 18:
 		goto st9;
 	goto st18;
 tr4:
-#line 161 "parser.rl"
+#line 163 "parser.rl"
 	{ p--; {p++; cs = 27; goto _out;} }
 	goto st27;
 st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 367 "parser.c"
+#line 369 "parser.c"
 	goto st0;
 st19:
 	if ( ++p == pe )
@@ -461,7 +463,7 @@ case 26:
 	_out: {}
 	}
 
-#line 187 "parser.rl"
+#line 189 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         if (json->create_additions) {
@@ -489,7 +491,7 @@ case 26:
 
 
 
-#line 493 "parser.c"
+#line 495 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -497,7 +499,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 290 "parser.rl"
+#line 292 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -505,14 +507,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 509 "parser.c"
+#line 511 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 297 "parser.rl"
+#line 299 "parser.rl"
 
-#line 516 "parser.c"
+#line 518 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -546,14 +548,14 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 242 "parser.rl"
+#line 244 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) { p--; {p++; cs = 29; goto _out;} } else {p = (( np))-1;}
     }
 	goto st29;
 tr3:
-#line 247 "parser.rl"
+#line 249 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -573,7 +575,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 265 "parser.rl"
+#line 267 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -581,7 +583,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 271 "parser.rl"
+#line 273 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -589,7 +591,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 235 "parser.rl"
+#line 237 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -599,7 +601,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 228 "parser.rl"
+#line 230 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -609,19 +611,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 222 "parser.rl"
+#line 224 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 219 "parser.rl"
+#line 221 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 225 "parser.rl"
+#line 227 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -630,9 +632,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 277 "parser.rl"
+#line 279 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 636 "parser.c"
+#line 638 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -873,7 +875,7 @@ case 28:
 	_out: {}
 	}
 
-#line 298 "parser.rl"
+#line 300 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -887,7 +889,7 @@ case 28:
 }
 
 
-#line 891 "parser.c"
+#line 893 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -895,7 +897,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 318 "parser.rl"
+#line 320 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -903,15 +905,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 907 "parser.c"
+#line 909 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 325 "parser.rl"
+#line 327 "parser.rl"
     json->memo = p;
 
-#line 915 "parser.c"
+#line 917 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -945,14 +947,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 315 "parser.rl"
+#line 317 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 956 "parser.c"
+#line 958 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -971,7 +973,7 @@ case 5:
 	_out: {}
 	}
 
-#line 327 "parser.rl"
+#line 329 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -986,7 +988,7 @@ case 5:
 }
 
 
-#line 990 "parser.c"
+#line 992 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -994,7 +996,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 352 "parser.rl"
+#line 354 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1002,15 +1004,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1006 "parser.c"
+#line 1008 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 359 "parser.rl"
+#line 361 "parser.rl"
     json->memo = p;
 
-#line 1014 "parser.c"
+#line 1016 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1068,14 +1070,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 346 "parser.rl"
+#line 348 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1079 "parser.c"
+#line 1081 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1136,7 +1138,7 @@ case 7:
 	_out: {}
 	}
 
-#line 361 "parser.rl"
+#line 363 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         VALUE mod = Qnil;
@@ -1189,7 +1191,7 @@ case 7:
 
 
 
-#line 1193 "parser.c"
+#line 1195 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 17};
 enum {JSON_array_error = 0};
@@ -1197,7 +1199,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 441 "parser.rl"
+#line 443 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1211,14 +1213,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     *result = array_class ? rb_class_new_instance(0, 0, array_class) : rb_ary_new();
 
 
-#line 1215 "parser.c"
+#line 1217 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 454 "parser.rl"
+#line 456 "parser.rl"
 
-#line 1222 "parser.c"
+#line 1224 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1257,7 +1259,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 418 "parser.rl"
+#line 420 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1277,7 +1279,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1281 "parser.c"
+#line 1283 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -1377,14 +1379,14 @@ case 12:
 		goto st3;
 	goto st12;
 tr4:
-#line 433 "parser.rl"
+#line 435 "parser.rl"
 	{ p--; {p++; cs = 17; goto _out;} }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1388 "parser.c"
+#line 1390 "parser.c"
 	goto st0;
 st13:
 	if ( ++p == pe )
@@ -1440,7 +1442,7 @@ case 16:
 	_out: {}
 	}
 
-#line 455 "parser.rl"
+#line 457 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         return p + 1;
@@ -1585,7 +1587,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, bool intern, bo
 }
 
 
-#line 1589 "parser.c"
+#line 1591 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -1593,7 +1595,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 617 "parser.rl"
+#line 619 "parser.rl"
 
 
 static int
@@ -1614,15 +1616,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 1618 "parser.c"
+#line 1620 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 637 "parser.rl"
+#line 639 "parser.rl"
     json->memo = p;
 
-#line 1626 "parser.c"
+#line 1628 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1647,7 +1649,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 604 "parser.rl"
+#line 606 "parser.rl"
 	{
         *result = json_string_unescape(json->memo + 1, p, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         if (NIL_P(*result)) {
@@ -1657,14 +1659,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 614 "parser.rl"
+#line 616 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1668 "parser.c"
+#line 1670 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -1740,7 +1742,7 @@ case 7:
 	_out: {}
 	}
 
-#line 639 "parser.rl"
+#line 641 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -1776,7 +1778,7 @@ static VALUE convert_encoding(VALUE source)
 {
   int encindex = RB_ENCODING_GET(source);
 
-  if (encindex == utf8_encindex) {
+  if (RB_LIKELY(encindex == utf8_encindex)) {
     return source;
   }
 
@@ -1786,6 +1788,32 @@ static VALUE convert_encoding(VALUE source)
   }
 
   return rb_funcall(source, i_encode, 1, Encoding_UTF_8);
+}
+
+static int configure_parser_i(VALUE key, VALUE val, VALUE data)
+{
+    JSON_Parser *json = (JSON_Parser *)data;
+
+         if (key == sym_max_nesting)       { json->max_nesting = RTEST(val) ? FIX2INT(val) : 0; }
+    else if (key == sym_allow_nan)         { json->allow_nan = RTEST(val); }
+    else if (key == sym_symbolize_names)   { json->symbolize_names = RTEST(val); }
+    else if (key == sym_freeze)            { json->freeze = RTEST(val); }
+    else if (key == sym_create_id)         { json->create_id = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_object_class)      { json->object_class = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_array_class)       { json->array_class = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_decimal_class)     { json->decimal_class = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_match_string)      { json->match_string = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_create_additions)  {
+        if (NIL_P(val)) {
+            json->create_additions = true;
+            json->deprecated_create_additions = true;
+        } else {
+            json->create_additions = RTEST(val);
+            json->deprecated_create_additions = false;
+        }
+    }
+
+    return ST_CONTINUE;
 }
 
 static void parser_init(JSON_Parser *json, VALUE source, VALUE opts)
@@ -1800,84 +1828,22 @@ static void parser_init(JSON_Parser *json, VALUE source, VALUE opts)
     if (!NIL_P(opts)) {
         Check_Type(opts, T_HASH);
         if (RHASH_SIZE(opts) > 0) {
-            VALUE tmp = ID2SYM(i_max_nesting);
-            if (option_given_p(opts, tmp)) {
-                VALUE max_nesting = rb_hash_aref(opts, tmp);
-                if (RTEST(max_nesting)) {
-                    Check_Type(max_nesting, T_FIXNUM);
-                    json->max_nesting = FIX2INT(max_nesting);
-                } else {
-                    json->max_nesting = 0;
-                }
-            } else {
-                json->max_nesting = 100;
-            }
-            tmp = ID2SYM(i_allow_nan);
-            if (option_given_p(opts, tmp)) {
-                json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-            } else {
-                json->allow_nan = false;
-            }
-            tmp = ID2SYM(i_symbolize_names);
-            if (option_given_p(opts, tmp)) {
-                json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-            } else {
-                json->symbolize_names = false;
-            }
-            tmp = ID2SYM(i_freeze);
-            if (option_given_p(opts, tmp)) {
-                json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
-            } else {
-                json->freeze = false;
-            }
-            tmp = ID2SYM(i_create_additions);
-            if (option_given_p(opts, tmp)) {
-                tmp = rb_hash_aref(opts, tmp);
-                if (NIL_P(tmp)) {
-                    json->create_additions = true;
-                    json->deprecated_create_additions = true;
-                } else {
-                    json->create_additions = RTEST(tmp);
-                    json->deprecated_create_additions = false;
-                }
-            }
+            // We assume in most cases few keys are set so it's faster to go over
+            // the provided keys than to check all possible keys.
+            rb_hash_foreach(opts, configure_parser_i, (VALUE)json);
 
             if (json->symbolize_names && json->create_additions) {
                 rb_raise(rb_eArgError,
                     "options :symbolize_names and :create_additions cannot be "
                     " used in conjunction");
             }
-            tmp = ID2SYM(i_create_id);
-            if (option_given_p(opts, tmp)) {
-                json->create_id = rb_hash_aref(opts, tmp);
-            } else {
+
+            if (json->create_additions && !json->create_id) {
                 json->create_id = rb_funcall(mJSON, i_create_id, 0);
             }
-            tmp = ID2SYM(i_object_class);
-            if (option_given_p(opts, tmp)) {
-                json->object_class = rb_hash_aref(opts, tmp);
-                if (NIL_P(json->object_class)) json->object_class = Qfalse;
-            }
-            tmp = ID2SYM(i_array_class);
-            if (option_given_p(opts, tmp)) {
-                json->array_class = rb_hash_aref(opts, tmp);
-                if (NIL_P(json->array_class)) json->array_class = Qfalse;
-            }
-
-            tmp = ID2SYM(i_decimal_class);
-            if (option_given_p(opts, tmp)) {
-                json->decimal_class = rb_hash_aref(opts, tmp);
-                if (NIL_P(json->decimal_class)) json->decimal_class = Qfalse;
-            }
-
-            tmp = ID2SYM(i_match_string);
-            if (option_given_p(opts, tmp)) {
-                VALUE match_string = rb_hash_aref(opts, tmp);
-                json->match_string = RTEST(match_string) ? match_string : Qfalse;
-            }
         }
-    }
 
+    }
     source = convert_encoding(StringValue(source));
     StringValue(source);
     json->len = RSTRING_LEN(source);
@@ -1928,7 +1894,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1932 "parser.c"
+#line 1898 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1936,7 +1902,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 840 "parser.rl"
+#line 806 "parser.rl"
 
 
 /*
@@ -1954,16 +1920,16 @@ static VALUE cParser_parse(VALUE self)
     GET_PARSER;
 
 
-#line 1958 "parser.c"
+#line 1924 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 857 "parser.rl"
+#line 823 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1967 "parser.c"
+#line 1933 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1997,7 +1963,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 832 "parser.rl"
+#line 798 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2007,7 +1973,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2011 "parser.c"
+#line 1977 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2096,7 +2062,7 @@ case 9:
 	_out: {}
 	}
 
-#line 860 "parser.rl"
+#line 826 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;
@@ -2117,16 +2083,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     parser_init(json, source, opts);
 
 
-#line 2121 "parser.c"
+#line 2087 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 880 "parser.rl"
+#line 846 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2130 "parser.c"
+#line 2096 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2160,7 +2126,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 832 "parser.rl"
+#line 798 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2170,7 +2136,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2174 "parser.c"
+#line 2140 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2259,7 +2225,7 @@ case 9:
 	_out: {}
 	}
 
-#line 883 "parser.rl"
+#line 849 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;
@@ -2352,26 +2318,28 @@ void Init_parser(void)
     rb_global_variable(&Encoding_UTF_8);
     Encoding_UTF_8 = rb_const_get(rb_path2class("Encoding"), rb_intern("UTF_8"));
 
+    sym_max_nesting = ID2SYM(rb_intern("max_nesting"));
+    sym_allow_nan = ID2SYM(rb_intern("allow_nan"));
+    sym_symbolize_names = ID2SYM(rb_intern("symbolize_names"));
+    sym_freeze = ID2SYM(rb_intern("freeze"));
+    sym_create_additions = ID2SYM(rb_intern("create_additions"));
+    sym_create_id = ID2SYM(rb_intern("create_id"));
+    sym_object_class = ID2SYM(rb_intern("object_class"));
+    sym_array_class = ID2SYM(rb_intern("array_class"));
+    sym_decimal_class = ID2SYM(rb_intern("decimal_class"));
+    sym_match_string = ID2SYM(rb_intern("match_string"));
+
+    i_create_id = rb_intern("create_id");
     i_json_creatable_p = rb_intern("json_creatable?");
     i_json_create = rb_intern("json_create");
-    i_create_id = rb_intern("create_id");
-    i_create_additions = rb_intern("create_additions");
     i_chr = rb_intern("chr");
-    i_max_nesting = rb_intern("max_nesting");
-    i_allow_nan = rb_intern("allow_nan");
-    i_symbolize_names = rb_intern("symbolize_names");
-    i_object_class = rb_intern("object_class");
-    i_array_class = rb_intern("array_class");
-    i_decimal_class = rb_intern("decimal_class");
     i_match = rb_intern("match");
-    i_match_string = rb_intern("match_string");
     i_deep_const_get = rb_intern("deep_const_get");
     i_aset = rb_intern("[]=");
     i_aref = rb_intern("[]");
     i_leftshift = rb_intern("<<");
     i_new = rb_intern("new");
     i_try_convert = rb_intern("try_convert");
-    i_freeze = rb_intern("freeze");
     i_uminus = rb_intern("-@");
     i_encode = rb_intern("encode");
 

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -38,12 +38,12 @@ typedef struct JSON_ParserStruct {
     VALUE match_string;
     FBuffer fbuffer;
     int max_nesting;
-    char allow_nan;
-    char parsing_name;
-    char symbolize_names;
-    char freeze;
-    char create_additions;
-    char deprecated_create_additions;
+    bool allow_nan;
+    bool parsing_name;
+    bool symbolize_names;
+    bool freeze;
+    bool create_additions;
+    bool deprecated_create_additions;
 } JSON_Parser;
 
 #define GET_PARSER                          \

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -24,8 +24,6 @@ typedef unsigned char _Bool;
 # define MAYBE_UNUSED(x) x
 #endif
 
-#define option_given_p(opts, key) (rb_hash_lookup2(opts, key, Qundef) != Qundef)
-
 typedef struct JSON_ParserStruct {
     VALUE Vsource;
     char *source;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -819,6 +819,9 @@ static VALUE cParser_parse(VALUE self)
     VALUE result = Qnil;
     GET_PARSER;
 
+    char stack_buffer[FBUFFER_STACK_SIZE];
+    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
+
     %% write init;
     p = json->source;
     pe = p + json->len;
@@ -841,6 +844,9 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     JSON_Parser parser = {0};
     JSON_Parser *json = &parser;
     parser_init(json, source, opts);
+
+    char stack_buffer[FBUFFER_STACK_SIZE];
+    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
 
     %% write init;
     p = json->source;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -152,9 +152,9 @@ static int utf8_encindex;
 
     action parse_name {
         char *np;
-        json->parsing_name = 1;
+        json->parsing_name = true;
         np = JSON_parse_string(json, fpc, pe, &last_name);
-        json->parsing_name = 0;
+        json->parsing_name = false;
         if (np == NULL) { fhold; fbreak; } else fexec np;
     }
 
@@ -711,29 +711,29 @@ static void parser_init(JSON_Parser *json, VALUE source, VALUE opts)
             if (option_given_p(opts, tmp)) {
                 json->allow_nan = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
             } else {
-                json->allow_nan = 0;
+                json->allow_nan = false;
             }
             tmp = ID2SYM(i_symbolize_names);
             if (option_given_p(opts, tmp)) {
                 json->symbolize_names = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
             } else {
-                json->symbolize_names = 0;
+                json->symbolize_names = false;
             }
             tmp = ID2SYM(i_freeze);
             if (option_given_p(opts, tmp)) {
                 json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
             } else {
-                json->freeze = 0;
+                json->freeze = false;
             }
             tmp = ID2SYM(i_create_additions);
             if (option_given_p(opts, tmp)) {
                 tmp = rb_hash_aref(opts, tmp);
                 if (NIL_P(tmp)) {
-                    json->create_additions = 1;
-                    json->deprecated_create_additions = 1;
+                    json->create_additions = true;
+                    json->deprecated_create_additions = true;
                 } else {
                     json->create_additions = RTEST(tmp);
-                    json->deprecated_create_additions = 0;
+                    json->deprecated_create_additions = false;
                 }
             }
 

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -159,6 +159,14 @@ public class Parser extends RubyObject {
         return parser;
     }
 
+    @JRubyMethod(meta=true)
+    public static IRubyObject parse(ThreadContext context, IRubyObject clazz, IRubyObject source, IRubyObject opts) {
+        IRubyObject[] args = new IRubyObject[] {source, opts};
+        Parser parser = (Parser)((RubyClass)clazz).allocate();
+        parser.callInit(args, null);
+        return parser.parse(context);
+    }
+
     @JRubyMethod(required = 1, optional = 1, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         Ruby runtime = context.getRuntime();
@@ -356,11 +364,11 @@ public class Parser extends RubyObject {
         }
 
         
-// line 382 "Parser.rl"
+// line 390 "Parser.rl"
 
 
         
-// line 364 "Parser.java"
+// line 372 "Parser.java"
 private static byte[] init__JSON_value_actions_0()
 {
 	return new byte [] {
@@ -474,7 +482,7 @@ static final int JSON_value_error = 0;
 static final int JSON_value_en_main = 1;
 
 
-// line 488 "Parser.rl"
+// line 496 "Parser.rl"
 
 
         void parseValue(ParserResult res, int p, int pe) {
@@ -482,14 +490,14 @@ static final int JSON_value_en_main = 1;
             IRubyObject result = null;
 
             
-// line 486 "Parser.java"
+// line 494 "Parser.java"
 	{
 	cs = JSON_value_start;
 	}
 
-// line 495 "Parser.rl"
+// line 503 "Parser.rl"
             
-// line 493 "Parser.java"
+// line 501 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -515,13 +523,13 @@ case 1:
 	while ( _nacts-- > 0 ) {
 		switch ( _JSON_value_actions[_acts++] ) {
 	case 9:
-// line 473 "Parser.rl"
+// line 481 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 525 "Parser.java"
+// line 533 "Parser.java"
 		}
 	}
 
@@ -584,25 +592,25 @@ case 1:
 			switch ( _JSON_value_actions[_acts++] )
 			{
 	case 0:
-// line 390 "Parser.rl"
+// line 398 "Parser.rl"
 	{
                 result = getRuntime().getNil();
             }
 	break;
 	case 1:
-// line 393 "Parser.rl"
+// line 401 "Parser.rl"
 	{
                 result = getRuntime().getFalse();
             }
 	break;
 	case 2:
-// line 396 "Parser.rl"
+// line 404 "Parser.rl"
 	{
                 result = getRuntime().getTrue();
             }
 	break;
 	case 3:
-// line 399 "Parser.rl"
+// line 407 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_NAN);
@@ -612,7 +620,7 @@ case 1:
             }
 	break;
 	case 4:
-// line 406 "Parser.rl"
+// line 414 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_INFINITY);
@@ -622,7 +630,7 @@ case 1:
             }
 	break;
 	case 5:
-// line 413 "Parser.rl"
+// line 421 "Parser.rl"
 	{
                 if (pe > p + 8 &&
                     absSubSequence(p, p + 9).equals(JSON_MINUS_INFINITY)) {
@@ -651,7 +659,7 @@ case 1:
             }
 	break;
 	case 6:
-// line 439 "Parser.rl"
+// line 447 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -664,7 +672,7 @@ case 1:
             }
 	break;
 	case 7:
-// line 449 "Parser.rl"
+// line 457 "Parser.rl"
 	{
                 currentNesting++;
                 parseArray(res, p, pe);
@@ -679,7 +687,7 @@ case 1:
             }
 	break;
 	case 8:
-// line 461 "Parser.rl"
+// line 469 "Parser.rl"
 	{
                 currentNesting++;
                 parseObject(res, p, pe);
@@ -693,7 +701,7 @@ case 1:
                 }
             }
 	break;
-// line 697 "Parser.java"
+// line 705 "Parser.java"
 			}
 		}
 	}
@@ -713,7 +721,7 @@ case 5:
 	break; }
 	}
 
-// line 496 "Parser.rl"
+// line 504 "Parser.rl"
 
             if (cs >= JSON_value_first_final && result != null) {
                 if (parser.freeze) {
@@ -726,7 +734,7 @@ case 5:
         }
 
         
-// line 730 "Parser.java"
+// line 738 "Parser.java"
 private static byte[] init__JSON_integer_actions_0()
 {
 	return new byte [] {
@@ -825,7 +833,7 @@ static final int JSON_integer_error = 0;
 static final int JSON_integer_en_main = 1;
 
 
-// line 518 "Parser.rl"
+// line 526 "Parser.rl"
 
 
         void parseInteger(ParserResult res, int p, int pe) {
@@ -843,15 +851,15 @@ static final int JSON_integer_en_main = 1;
             int cs = EVIL;
 
             
-// line 847 "Parser.java"
+// line 855 "Parser.java"
 	{
 	cs = JSON_integer_start;
 	}
 
-// line 535 "Parser.rl"
+// line 543 "Parser.rl"
             int memo = p;
             
-// line 855 "Parser.java"
+// line 863 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -932,13 +940,13 @@ case 1:
 			switch ( _JSON_integer_actions[_acts++] )
 			{
 	case 0:
-// line 512 "Parser.rl"
+// line 520 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 942 "Parser.java"
+// line 950 "Parser.java"
 			}
 		}
 	}
@@ -958,7 +966,7 @@ case 5:
 	break; }
 	}
 
-// line 537 "Parser.rl"
+// line 545 "Parser.rl"
 
             if (cs < JSON_integer_first_final) {
                 return -1;
@@ -978,7 +986,7 @@ case 5:
         }
 
         
-// line 982 "Parser.java"
+// line 990 "Parser.java"
 private static byte[] init__JSON_float_actions_0()
 {
 	return new byte [] {
@@ -1080,7 +1088,7 @@ static final int JSON_float_error = 0;
 static final int JSON_float_en_main = 1;
 
 
-// line 570 "Parser.rl"
+// line 578 "Parser.rl"
 
 
         void parseFloat(ParserResult res, int p, int pe) {
@@ -1099,15 +1107,15 @@ static final int JSON_float_en_main = 1;
             int cs = EVIL;
 
             
-// line 1103 "Parser.java"
+// line 1111 "Parser.java"
 	{
 	cs = JSON_float_start;
 	}
 
-// line 588 "Parser.rl"
+// line 596 "Parser.rl"
             int memo = p;
             
-// line 1111 "Parser.java"
+// line 1119 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1188,13 +1196,13 @@ case 1:
 			switch ( _JSON_float_actions[_acts++] )
 			{
 	case 0:
-// line 561 "Parser.rl"
+// line 569 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1198 "Parser.java"
+// line 1206 "Parser.java"
 			}
 		}
 	}
@@ -1214,7 +1222,7 @@ case 5:
 	break; }
 	}
 
-// line 590 "Parser.rl"
+// line 598 "Parser.rl"
 
             if (cs < JSON_float_first_final) {
                 return -1;
@@ -1224,7 +1232,7 @@ case 5:
         }
 
         
-// line 1228 "Parser.java"
+// line 1236 "Parser.java"
 private static byte[] init__JSON_string_actions_0()
 {
 	return new byte [] {
@@ -1326,7 +1334,7 @@ static final int JSON_string_error = 0;
 static final int JSON_string_en_main = 1;
 
 
-// line 629 "Parser.rl"
+// line 637 "Parser.rl"
 
 
         void parseString(ParserResult res, int p, int pe) {
@@ -1334,15 +1342,15 @@ static final int JSON_string_en_main = 1;
             IRubyObject result = null;
 
             
-// line 1338 "Parser.java"
+// line 1346 "Parser.java"
 	{
 	cs = JSON_string_start;
 	}
 
-// line 636 "Parser.rl"
+// line 644 "Parser.rl"
             int memo = p;
             
-// line 1346 "Parser.java"
+// line 1354 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1423,7 +1431,7 @@ case 1:
 			switch ( _JSON_string_actions[_acts++] )
 			{
 	case 0:
-// line 604 "Parser.rl"
+// line 612 "Parser.rl"
 	{
                 int offset = byteList.begin();
                 ByteList decoded = decoder.decode(byteList, memo + 1 - offset,
@@ -1438,13 +1446,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 617 "Parser.rl"
+// line 625 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1448 "Parser.java"
+// line 1456 "Parser.java"
 			}
 		}
 	}
@@ -1464,7 +1472,7 @@ case 5:
 	break; }
 	}
 
-// line 638 "Parser.rl"
+// line 646 "Parser.rl"
 
             if (parser.createAdditions) {
                 RubyHash matchString = parser.match_string;
@@ -1512,7 +1520,7 @@ case 5:
         }
 
         
-// line 1516 "Parser.java"
+// line 1524 "Parser.java"
 private static byte[] init__JSON_array_actions_0()
 {
 	return new byte [] {
@@ -1625,7 +1633,7 @@ static final int JSON_array_error = 0;
 static final int JSON_array_en_main = 1;
 
 
-// line 721 "Parser.rl"
+// line 729 "Parser.rl"
 
 
         void parseArray(ParserResult res, int p, int pe) {
@@ -1645,14 +1653,14 @@ static final int JSON_array_en_main = 1;
             }
 
             
-// line 1649 "Parser.java"
+// line 1657 "Parser.java"
 	{
 	cs = JSON_array_start;
 	}
 
-// line 740 "Parser.rl"
+// line 748 "Parser.rl"
             
-// line 1656 "Parser.java"
+// line 1664 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1733,7 +1741,7 @@ case 1:
 			switch ( _JSON_array_actions[_acts++] )
 			{
 	case 0:
-// line 690 "Parser.rl"
+// line 698 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1750,13 +1758,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 705 "Parser.rl"
+// line 713 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1760 "Parser.java"
+// line 1768 "Parser.java"
 			}
 		}
 	}
@@ -1776,7 +1784,7 @@ case 5:
 	break; }
 	}
 
-// line 741 "Parser.rl"
+// line 749 "Parser.rl"
 
             if (cs >= JSON_array_first_final) {
                 res.update(result, p + 1);
@@ -1786,7 +1794,7 @@ case 5:
         }
 
         
-// line 1790 "Parser.java"
+// line 1798 "Parser.java"
 private static byte[] init__JSON_object_actions_0()
 {
 	return new byte [] {
@@ -1909,7 +1917,7 @@ static final int JSON_object_error = 0;
 static final int JSON_object_en_main = 1;
 
 
-// line 798 "Parser.rl"
+// line 806 "Parser.rl"
 
 
         void parseObject(ParserResult res, int p, int pe) {
@@ -1934,14 +1942,14 @@ static final int JSON_object_en_main = 1;
             }
 
             
-// line 1938 "Parser.java"
+// line 1946 "Parser.java"
 	{
 	cs = JSON_object_start;
 	}
 
-// line 822 "Parser.rl"
+// line 830 "Parser.rl"
             
-// line 1945 "Parser.java"
+// line 1953 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2022,7 +2030,7 @@ case 1:
 			switch ( _JSON_object_actions[_acts++] )
 			{
 	case 0:
-// line 755 "Parser.rl"
+// line 763 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2039,7 +2047,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 770 "Parser.rl"
+// line 778 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -2057,13 +2065,13 @@ case 1:
             }
 	break;
 	case 2:
-// line 786 "Parser.rl"
+// line 794 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 2067 "Parser.java"
+// line 2075 "Parser.java"
 			}
 		}
 	}
@@ -2083,7 +2091,7 @@ case 5:
 	break; }
 	}
 
-// line 823 "Parser.rl"
+// line 831 "Parser.rl"
 
             if (cs < JSON_object_first_final) {
                 res.update(null, p + 1);
@@ -2119,7 +2127,7 @@ case 5:
         }
 
         
-// line 2123 "Parser.java"
+// line 2131 "Parser.java"
 private static byte[] init__JSON_actions_0()
 {
 	return new byte [] {
@@ -2222,7 +2230,7 @@ static final int JSON_error = 0;
 static final int JSON_en_main = 1;
 
 
-// line 877 "Parser.rl"
+// line 885 "Parser.rl"
 
 
         public IRubyObject parseImplemetation() {
@@ -2232,16 +2240,16 @@ static final int JSON_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2236 "Parser.java"
+// line 2244 "Parser.java"
 	{
 	cs = JSON_start;
 	}
 
-// line 886 "Parser.rl"
+// line 894 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2245 "Parser.java"
+// line 2253 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2322,7 +2330,7 @@ case 1:
 			switch ( _JSON_actions[_acts++] )
 			{
 	case 0:
-// line 863 "Parser.rl"
+// line 871 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2334,7 +2342,7 @@ case 1:
                 }
             }
 	break;
-// line 2338 "Parser.java"
+// line 2346 "Parser.java"
 			}
 		}
 	}
@@ -2354,7 +2362,7 @@ case 5:
 	break; }
 	}
 
-// line 889 "Parser.rl"
+// line 897 "Parser.rl"
 
             if (cs >= JSON_first_final && p == pe) {
                 return result;

--- a/java/src/json/ext/Parser.rl
+++ b/java/src/json/ext/Parser.rl
@@ -157,6 +157,14 @@ public class Parser extends RubyObject {
         return parser;
     }
 
+    @JRubyMethod(meta=true)
+    public static IRubyObject parse(ThreadContext context, IRubyObject clazz, IRubyObject source, IRubyObject opts) {
+        IRubyObject[] args = new IRubyObject[] {source, opts};
+        Parser parser = (Parser)((RubyClass)clazz).allocate();
+        parser.callInit(args, null);
+        return parser.parse(context);
+    }
+
     @JRubyMethod(required = 1, optional = 1, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         Ruby runtime = context.getRuntime();

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -207,16 +207,7 @@ module JSON
   #   JSON.parse('')
   #
   def parse(source, opts = nil)
-    if opts.nil?
-      Parser.new(source).parse
-    else
-      # NB: The ** shouldn't be required, but we have to deal with
-      # different versions of the `json` and `json_pure` gems being
-      # loaded concurrently.
-      # Prior to 2.7.3, `JSON::Ext::Parser` would only take kwargs.
-      # Ref: https://github.com/ruby/json/issues/650
-      Parser.new(source, **opts).parse
-    end
+    Parser.parse(source, opts)
   end
 
   # :call-seq:

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -48,6 +48,21 @@ module JSON
 
       UNPARSED = Object.new.freeze
 
+      class << self
+        def parse(source, opts = nil)
+          if opts.nil?
+            new(source).parse
+          else
+            # NB: The ** shouldn't be required, but we have to deal with
+            # different versions of the `json` and `json_pure` gems being
+            # loaded concurrently.
+            # Prior to 2.7.3, `JSON::Ext::Parser` would only take kwargs.
+            # Ref: https://github.com/ruby/json/issues/650
+            new(source, **opts).parse
+          end
+        end
+      end
+
       # Creates a new JSON::Pure::Parser instance for the string _source_.
       #
       # It will be configured by the _opts_ hash. _opts_ can have the following


### PR DESCRIPTION
Similar to the optimizations done for the generator, but here it's even simpler because we never need to spill the `Parser` object on the heap.

We also start the parsing buffer with 512B of stack memory, so that in most case no allocations other than the returned value are necessary.

This mostly help on micro-benchmarks, but isn't detrimental to more real world benchmarks.

Before:


```
== Parsing small hash (65 bytes)
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                json   188.233k i/100ms
                  oj   213.985k i/100ms
           oj strict   242.564k i/100ms
          Oj::Parser   448.682k i/100ms
           rapidjson   291.925k i/100ms
Calculating -------------------------------------
                json      1.983M (± 0.5%) i/s  (504.32 ns/i) -      9.976M in   5.031352s
                  oj      2.334M (± 0.2%) i/s  (428.48 ns/i) -     11.769M in   5.042839s
           oj strict      2.689M (± 0.2%) i/s  (371.85 ns/i) -     13.584M in   5.051044s
          Oj::Parser      4.662M (± 1.2%) i/s  (214.50 ns/i) -     23.331M in   5.005414s
           rapidjson      3.110M (± 0.7%) i/s  (321.57 ns/i) -     15.764M in   5.069531s

Comparison:
                json:  1982878.1 i/s
          Oj::Parser:  4661924.8 i/s - 2.35x  faster
           rapidjson:  3109722.2 i/s - 1.57x  faster
           oj strict:  2689277.0 i/s - 1.36x  faster
                  oj:  2333852.9 i/s - 1.18x  faster
```

After:

```
== Parsing small hash (65 bytes)
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
                json   304.417k i/100ms
                  oj   219.431k i/100ms
           oj strict   254.532k i/100ms
          Oj::Parser   431.309k i/100ms
           rapidjson   281.703k i/100ms
Calculating -------------------------------------
                json      3.046M (± 0.1%) i/s  (328.25 ns/i) -     15.525M in   5.096243s
                  oj      2.225M (± 0.2%) i/s  (449.50 ns/i) -     11.191M in   5.030429s
           oj strict      2.553M (± 0.5%) i/s  (391.75 ns/i) -     12.981M in   5.085538s
          Oj::Parser      4.280M (± 0.8%) i/s  (233.64 ns/i) -     21.565M in   5.038834s
           rapidjson      2.826M (± 0.3%) i/s  (353.83 ns/i) -     14.367M in   5.083480s

Comparison:
                json:  3046420.8 i/s
          Oj::Parser:  4280132.7 i/s - 1.40x  faster
           rapidjson:  2826209.4 i/s - 1.08x  slower
           oj strict:  2552619.7 i/s - 1.19x  slower
                  oj:  2224670.7 i/s - 1.37x  slower
```
