### PR TITLE
Speedup #generate_json by using case/when/end

### DIFF
--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -32,8 +32,6 @@ class JSONParserTest < Test::Unit::TestCase
   end
 
   def test_error_message_encoding
-    pend if RUBY_ENGINE == 'truffleruby'
-
     bug10705 = '[ruby-core:67386] [Bug #10705]'
     json = ".\"\xE2\x88\x9A\""
     assert_equal(Encoding::UTF_8, json.encoding)


### PR DESCRIPTION
* if/elsif comparing `obj.class` is significantly slower: https://github.com/ruby/json/pull/668#issuecomment-2450747190
* The only case where an exact class check is needed so far is for String (https://github.com/ruby/json/issues/667).
* Before:
```
$ ruby -Ilib:ext benchmark/standalone.rb dump pure JSON::Pure::Generator
truffleruby 24.2.0-dev-07b978e4, like ruby 3.2.4, Oracle GraalVM JVM [x86_64-linux] Calculating -------------------------------------
      JSON.dump(obj)      6.426k (± 5.9%) i/s  (155.62 μs/i) -     32.395k in   5.064479s
      JSON.dump(obj)      6.380k (± 7.4%) i/s  (156.73 μs/i) -     31.806k in   5.021304s
      JSON.dump(obj)      6.276k (±10.5%) i/s  (159.33 μs/i) -     31.217k in   5.060762s
      JSON.dump(obj)      6.450k (± 7.0%) i/s  (155.05 μs/i) -     32.395k in   5.059538s
      JSON.dump(obj)      6.413k (± 6.2%) i/s  (155.93 μs/i) -     32.395k in   5.081573s
```
* After:
```
$ ruby -Ilib:ext benchmark/standalone.rb dump pure
JSON::Pure::Generator
truffleruby 24.2.0-dev-07b978e4, like ruby 3.2.4, Oracle GraalVM JVM [x86_64-linux]
Calculating -------------------------------------
      JSON.dump(obj)      8.237k (± 5.0%) i/s  (121.41 μs/i) -     41.600k in   5.069507s
      JSON.dump(obj)      8.179k (± 5.1%) i/s  (122.26 μs/i) -     40.768k in   5.002035s
      JSON.dump(obj)      8.147k (± 7.9%) i/s  (122.74 μs/i) -     40.768k in   5.044840s
      JSON.dump(obj)      8.137k (± 6.9%) i/s  (122.90 μs/i) -     40.768k in   5.048690s
      JSON.dump(obj)      8.112k (±10.2%) i/s  (123.27 μs/i) -     39.936k in   5.023502s
```