### PR TITLE
Add option :allow_trailing_comma to JSON#parse

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -10,7 +10,7 @@ static ID i_json_creatable_p, i_json_create, i_create_id,
           i_chr, i_deep_const_get, i_match, i_aset, i_aref,
           i_leftshift, i_new, i_try_convert, i_uminus, i_encode;
 
-static VALUE sym_max_nesting, sym_allow_nan, sym_symbolize_names, sym_freeze,
+static VALUE sym_max_nesting, sym_allow_nan, sym_allow_trailing_comma, sym_symbolize_names, sym_freeze,
              sym_create_additions, sym_create_id, sym_object_class, sym_array_class,
              sym_decimal_class, sym_match_string;
 
@@ -385,6 +385,7 @@ typedef struct JSON_ParserStruct {
     FBuffer fbuffer;
     int max_nesting;
     bool allow_nan;
+    bool allow_trailing_comma;
     bool parsing_name;
     bool symbolize_names;
     bool freeze;
@@ -437,19 +438,19 @@ static void raise_parse_error(const char *format, const char *start)
 
 
 
-#line 463 "parser.rl"
+#line 464 "parser.rl"
 
 
 
-#line 445 "parser.c"
+#line 446 "parser.c"
 enum {JSON_object_start = 1};
-enum {JSON_object_first_final = 27};
+enum {JSON_object_first_final = 32};
 enum {JSON_object_error = 0};
 
 enum {JSON_object_en_main = 1};
 
 
-#line 501 "parser.rl"
+#line 504 "parser.rl"
 
 
 #define PUSH(result) rvalue_stack_push(json->stack, result, &json->stack_handle, &json->stack)
@@ -465,15 +466,16 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     long stack_head = json->stack->head;
 
 
-#line 469 "parser.c"
+#line 470 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 516 "parser.rl"
+#line 519 "parser.rl"
 
-#line 476 "parser.c"
+#line 477 "parser.c"
 	{
+	short _widec;
 	if ( p == pe )
 		goto _test_eof;
 	switch ( cs )
@@ -493,14 +495,14 @@ case 2:
 		case 13: goto st2;
 		case 32: goto st2;
 		case 34: goto tr2;
-		case 47: goto st23;
+		case 47: goto st28;
 		case 125: goto tr4;
 	}
 	if ( 9 <= (*p) && (*p) <= 10 )
 		goto st2;
 	goto st0;
 tr2:
-#line 480 "parser.rl"
+#line 483 "parser.rl"
 	{
         char *np;
         json->parsing_name = true;
@@ -516,7 +518,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 520 "parser.c"
+#line 522 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -567,7 +569,7 @@ case 8:
 		case 32: goto st8;
 		case 34: goto tr11;
 		case 45: goto tr11;
-		case 47: goto st19;
+		case 47: goto st24;
 		case 73: goto tr11;
 		case 78: goto tr11;
 		case 91: goto tr11;
@@ -583,7 +585,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 471 "parser.rl"
+#line 472 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, result, current_nesting);
         if (np == NULL) {
@@ -597,16 +599,75 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 601 "parser.c"
-	switch( (*p) ) {
-		case 13: goto st9;
-		case 32: goto st9;
-		case 44: goto st10;
-		case 47: goto st15;
-		case 125: goto tr4;
+#line 603 "parser.c"
+	_widec = (*p);
+	if ( (*p) < 13 ) {
+		if ( (*p) > 9 ) {
+			if ( 10 <= (*p) && (*p) <= 10 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else if ( (*p) >= 9 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 13 ) {
+		if ( (*p) < 44 ) {
+			if ( 32 <= (*p) && (*p) <= 32 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else if ( (*p) > 44 ) {
+			if ( 47 <= (*p) && (*p) <= 47 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
 	}
-	if ( 9 <= (*p) && (*p) <= 10 )
-		goto st9;
+	switch( _widec ) {
+		case 125: goto tr4;
+		case 269: goto st10;
+		case 288: goto st10;
+		case 300: goto st11;
+		case 303: goto st16;
+		case 525: goto st9;
+		case 544: goto st9;
+		case 556: goto st2;
+		case 559: goto st20;
+	}
+	if ( _widec > 266 ) {
+		if ( 521 <= _widec && _widec <= 522 )
+			goto st9;
+	} else if ( _widec >= 265 )
+		goto st10;
+	goto st0;
+tr4:
+#line 494 "parser.rl"
+	{ p--; {p++; cs = 32; goto _out;} }
+	goto st32;
+st32:
+	if ( ++p == pe )
+		goto _test_eof32;
+case 32:
+#line 671 "parser.c"
 	goto st0;
 st10:
 	if ( ++p == pe )
@@ -615,8 +676,9 @@ case 10:
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
-		case 34: goto tr2;
-		case 47: goto st11;
+		case 44: goto st11;
+		case 47: goto st16;
+		case 125: goto tr4;
 	}
 	if ( 9 <= (*p) && (*p) <= 10 )
 		goto st10;
@@ -626,139 +688,288 @@ st11:
 		goto _test_eof11;
 case 11:
 	switch( (*p) ) {
-		case 42: goto st12;
-		case 47: goto st14;
+		case 13: goto st11;
+		case 32: goto st11;
+		case 34: goto tr2;
+		case 47: goto st12;
 	}
+	if ( 9 <= (*p) && (*p) <= 10 )
+		goto st11;
 	goto st0;
 st12:
 	if ( ++p == pe )
 		goto _test_eof12;
 case 12:
-	if ( (*p) == 42 )
-		goto st13;
-	goto st12;
+	switch( (*p) ) {
+		case 42: goto st13;
+		case 47: goto st15;
+	}
+	goto st0;
 st13:
 	if ( ++p == pe )
 		goto _test_eof13;
 case 13:
-	switch( (*p) ) {
-		case 42: goto st13;
-		case 47: goto st10;
-	}
-	goto st12;
+	if ( (*p) == 42 )
+		goto st14;
+	goto st13;
 st14:
 	if ( ++p == pe )
 		goto _test_eof14;
 case 14:
-	if ( (*p) == 10 )
-		goto st10;
-	goto st14;
+	switch( (*p) ) {
+		case 42: goto st14;
+		case 47: goto st11;
+	}
+	goto st13;
 st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-	switch( (*p) ) {
-		case 42: goto st16;
-		case 47: goto st18;
-	}
-	goto st0;
+	if ( (*p) == 10 )
+		goto st11;
+	goto st15;
 st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-	if ( (*p) == 42 )
-		goto st17;
-	goto st16;
+	switch( (*p) ) {
+		case 42: goto st17;
+		case 47: goto st19;
+	}
+	goto st0;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-	switch( (*p) ) {
-		case 42: goto st17;
-		case 47: goto st9;
-	}
-	goto st16;
+	if ( (*p) == 42 )
+		goto st18;
+	goto st17;
 st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-	if ( (*p) == 10 )
-		goto st9;
-	goto st18;
-tr4:
-#line 491 "parser.rl"
-	{ p--; {p++; cs = 27; goto _out;} }
-	goto st27;
-st27:
-	if ( ++p == pe )
-		goto _test_eof27;
-case 27:
-#line 697 "parser.c"
-	goto st0;
+	switch( (*p) ) {
+		case 42: goto st18;
+		case 47: goto st10;
+	}
+	goto st17;
 st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-	switch( (*p) ) {
-		case 42: goto st20;
-		case 47: goto st22;
-	}
-	goto st0;
+	if ( (*p) == 10 )
+		goto st10;
+	goto st19;
 st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-	if ( (*p) == 42 )
-		goto st21;
-	goto st20;
+	_widec = (*p);
+	if ( (*p) > 42 ) {
+		if ( 47 <= (*p) && (*p) <= 47 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) >= 42 ) {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+	}
+	switch( _widec ) {
+		case 298: goto st17;
+		case 303: goto st19;
+		case 554: goto st21;
+		case 559: goto st23;
+	}
+	goto st0;
 st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-	switch( (*p) ) {
-		case 42: goto st21;
-		case 47: goto st8;
+	_widec = (*p);
+	if ( (*p) < 42 ) {
+		if ( (*p) <= 41 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 42 ) {
+		if ( 43 <= (*p) )
+ {			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
 	}
-	goto st20;
+	switch( _widec ) {
+		case 298: goto st18;
+		case 554: goto st22;
+	}
+	if ( _widec > 383 ) {
+		if ( 384 <= _widec && _widec <= 639 )
+			goto st21;
+	} else if ( _widec >= 128 )
+		goto st17;
+	goto st0;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-	if ( (*p) == 10 )
-		goto st8;
-	goto st22;
+	_widec = (*p);
+	if ( (*p) < 43 ) {
+		if ( (*p) > 41 ) {
+			if ( 42 <= (*p) && (*p) <= 42 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 46 ) {
+		if ( (*p) > 47 ) {
+			if ( 48 <= (*p) )
+ {				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else if ( (*p) >= 47 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+	}
+	switch( _widec ) {
+		case 298: goto st18;
+		case 303: goto st10;
+		case 554: goto st22;
+		case 559: goto st9;
+	}
+	if ( _widec > 383 ) {
+		if ( 384 <= _widec && _widec <= 639 )
+			goto st21;
+	} else if ( _widec >= 128 )
+		goto st17;
+	goto st0;
 st23:
 	if ( ++p == pe )
 		goto _test_eof23;
 case 23:
-	switch( (*p) ) {
-		case 42: goto st24;
-		case 47: goto st26;
+	_widec = (*p);
+	if ( (*p) < 10 ) {
+		if ( (*p) <= 9 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 10 ) {
+		if ( 11 <= (*p) )
+ {			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 481 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
 	}
+	switch( _widec ) {
+		case 266: goto st10;
+		case 522: goto st9;
+	}
+	if ( _widec > 383 ) {
+		if ( 384 <= _widec && _widec <= 639 )
+			goto st23;
+	} else if ( _widec >= 128 )
+		goto st19;
 	goto st0;
 st24:
 	if ( ++p == pe )
 		goto _test_eof24;
 case 24:
-	if ( (*p) == 42 )
-		goto st25;
-	goto st24;
+	switch( (*p) ) {
+		case 42: goto st25;
+		case 47: goto st27;
+	}
+	goto st0;
 st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-	switch( (*p) ) {
-		case 42: goto st25;
-		case 47: goto st2;
-	}
-	goto st24;
+	if ( (*p) == 42 )
+		goto st26;
+	goto st25;
 st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
+	switch( (*p) ) {
+		case 42: goto st26;
+		case 47: goto st8;
+	}
+	goto st25;
+st27:
+	if ( ++p == pe )
+		goto _test_eof27;
+case 27:
+	if ( (*p) == 10 )
+		goto st8;
+	goto st27;
+st28:
+	if ( ++p == pe )
+		goto _test_eof28;
+case 28:
+	switch( (*p) ) {
+		case 42: goto st29;
+		case 47: goto st31;
+	}
+	goto st0;
+st29:
+	if ( ++p == pe )
+		goto _test_eof29;
+case 29:
+	if ( (*p) == 42 )
+		goto st30;
+	goto st29;
+st30:
+	if ( ++p == pe )
+		goto _test_eof30;
+case 30:
+	switch( (*p) ) {
+		case 42: goto st30;
+		case 47: goto st2;
+	}
+	goto st29;
+st31:
+	if ( ++p == pe )
+		goto _test_eof31;
+case 31:
 	if ( (*p) == 10 )
 		goto st2;
-	goto st26;
+	goto st31;
 	}
 	_test_eof2: cs = 2; goto _test_eof;
 	_test_eof3: cs = 3; goto _test_eof;
@@ -768,6 +979,7 @@ case 26:
 	_test_eof7: cs = 7; goto _test_eof;
 	_test_eof8: cs = 8; goto _test_eof;
 	_test_eof9: cs = 9; goto _test_eof;
+	_test_eof32: cs = 32; goto _test_eof;
 	_test_eof10: cs = 10; goto _test_eof;
 	_test_eof11: cs = 11; goto _test_eof;
 	_test_eof12: cs = 12; goto _test_eof;
@@ -777,7 +989,6 @@ case 26:
 	_test_eof16: cs = 16; goto _test_eof;
 	_test_eof17: cs = 17; goto _test_eof;
 	_test_eof18: cs = 18; goto _test_eof;
-	_test_eof27: cs = 27; goto _test_eof;
 	_test_eof19: cs = 19; goto _test_eof;
 	_test_eof20: cs = 20; goto _test_eof;
 	_test_eof21: cs = 21; goto _test_eof;
@@ -786,12 +997,17 @@ case 26:
 	_test_eof24: cs = 24; goto _test_eof;
 	_test_eof25: cs = 25; goto _test_eof;
 	_test_eof26: cs = 26; goto _test_eof;
+	_test_eof27: cs = 27; goto _test_eof;
+	_test_eof28: cs = 28; goto _test_eof;
+	_test_eof29: cs = 29; goto _test_eof;
+	_test_eof30: cs = 30; goto _test_eof;
+	_test_eof31: cs = 31; goto _test_eof;
 
 	_test_eof: {}
 	_out: {}
 	}
 
-#line 517 "parser.rl"
+#line 520 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         long count = json->stack->head - stack_head;
@@ -842,7 +1058,7 @@ case 26:
 }
 
 
-#line 846 "parser.c"
+#line 1062 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -850,7 +1066,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 652 "parser.rl"
+#line 655 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -858,14 +1074,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 862 "parser.c"
+#line 1078 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 659 "parser.rl"
+#line 662 "parser.rl"
 
-#line 869 "parser.c"
+#line 1085 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -899,7 +1115,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 595 "parser.rl"
+#line 598 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) {
@@ -911,7 +1127,7 @@ tr2:
     }
 	goto st29;
 tr3:
-#line 605 "parser.rl"
+#line 608 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -935,7 +1151,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 627 "parser.rl"
+#line 630 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -943,7 +1159,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 633 "parser.rl"
+#line 636 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -951,7 +1167,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 588 "parser.rl"
+#line 591 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -961,7 +1177,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 581 "parser.rl"
+#line 584 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -971,19 +1187,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 575 "parser.rl"
+#line 578 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 572 "parser.rl"
+#line 575 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 578 "parser.rl"
+#line 581 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -992,9 +1208,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 639 "parser.rl"
+#line 642 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 998 "parser.c"
+#line 1214 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -1235,7 +1451,7 @@ case 28:
 	_out: {}
 	}
 
-#line 660 "parser.rl"
+#line 663 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -1250,7 +1466,7 @@ case 28:
 }
 
 
-#line 1254 "parser.c"
+#line 1470 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -1258,7 +1474,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 681 "parser.rl"
+#line 684 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1266,15 +1482,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 1270 "parser.c"
+#line 1486 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 688 "parser.rl"
+#line 691 "parser.rl"
     json->memo = p;
 
-#line 1278 "parser.c"
+#line 1494 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1308,14 +1524,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 678 "parser.rl"
+#line 681 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 1319 "parser.c"
+#line 1535 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1334,7 +1550,7 @@ case 5:
 	_out: {}
 	}
 
-#line 690 "parser.rl"
+#line 693 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -1349,7 +1565,7 @@ case 5:
 }
 
 
-#line 1353 "parser.c"
+#line 1569 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -1357,7 +1573,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 715 "parser.rl"
+#line 718 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1365,15 +1581,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1369 "parser.c"
+#line 1585 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 722 "parser.rl"
+#line 725 "parser.rl"
     json->memo = p;
 
-#line 1377 "parser.c"
+#line 1593 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1431,14 +1647,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 709 "parser.rl"
+#line 712 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1442 "parser.c"
+#line 1658 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1499,7 +1715,7 @@ case 7:
 	_out: {}
 	}
 
-#line 724 "parser.rl"
+#line 727 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         VALUE mod = Qnil;
@@ -1552,15 +1768,15 @@ case 7:
 
 
 
-#line 1556 "parser.c"
+#line 1772 "parser.c"
 enum {JSON_array_start = 1};
-enum {JSON_array_first_final = 17};
+enum {JSON_array_first_final = 22};
 enum {JSON_array_error = 0};
 
 enum {JSON_array_en_main = 1};
 
 
-#line 799 "parser.rl"
+#line 804 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1573,15 +1789,16 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     long stack_head = json->stack->head;
 
 
-#line 1577 "parser.c"
+#line 1793 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 811 "parser.rl"
+#line 816 "parser.rl"
 
-#line 1584 "parser.c"
+#line 1800 "parser.c"
 	{
+	short _widec;
 	if ( p == pe )
 		goto _test_eof;
 	switch ( cs )
@@ -1602,7 +1819,7 @@ case 2:
 		case 32: goto st2;
 		case 34: goto tr2;
 		case 45: goto tr2;
-		case 47: goto st13;
+		case 47: goto st18;
 		case 73: goto tr2;
 		case 78: goto tr2;
 		case 91: goto tr2;
@@ -1619,7 +1836,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 781 "parser.rl"
+#line 784 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1634,15 +1851,23 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1638 "parser.c"
-	switch( (*p) ) {
+#line 1855 "parser.c"
+	_widec = (*p);
+	if ( 44 <= (*p) && (*p) <= 44 ) {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+	}
+	switch( _widec ) {
 		case 13: goto st3;
 		case 32: goto st3;
-		case 44: goto st4;
-		case 47: goto st9;
+		case 47: goto st4;
 		case 93: goto tr4;
+		case 300: goto st8;
+		case 556: goto st13;
 	}
-	if ( 9 <= (*p) && (*p) <= 10 )
+	if ( 9 <= _widec && _widec <= 10 )
 		goto st3;
 	goto st0;
 st4:
@@ -1650,11 +1875,53 @@ st4:
 		goto _test_eof4;
 case 4:
 	switch( (*p) ) {
-		case 13: goto st4;
-		case 32: goto st4;
+		case 42: goto st5;
+		case 47: goto st7;
+	}
+	goto st0;
+st5:
+	if ( ++p == pe )
+		goto _test_eof5;
+case 5:
+	if ( (*p) == 42 )
+		goto st6;
+	goto st5;
+st6:
+	if ( ++p == pe )
+		goto _test_eof6;
+case 6:
+	switch( (*p) ) {
+		case 42: goto st6;
+		case 47: goto st3;
+	}
+	goto st5;
+st7:
+	if ( ++p == pe )
+		goto _test_eof7;
+case 7:
+	if ( (*p) == 10 )
+		goto st3;
+	goto st7;
+tr4:
+#line 796 "parser.rl"
+	{ p--; {p++; cs = 22; goto _out;} }
+	goto st22;
+st22:
+	if ( ++p == pe )
+		goto _test_eof22;
+case 22:
+#line 1914 "parser.c"
+	goto st0;
+st8:
+	if ( ++p == pe )
+		goto _test_eof8;
+case 8:
+	switch( (*p) ) {
+		case 13: goto st8;
+		case 32: goto st8;
 		case 34: goto tr2;
 		case 45: goto tr2;
-		case 47: goto st5;
+		case 47: goto st9;
 		case 73: goto tr2;
 		case 78: goto tr2;
 		case 91: goto tr2;
@@ -1667,40 +1934,8 @@ case 4:
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr2;
 	} else if ( (*p) >= 9 )
-		goto st4;
+		goto st8;
 	goto st0;
-st5:
-	if ( ++p == pe )
-		goto _test_eof5;
-case 5:
-	switch( (*p) ) {
-		case 42: goto st6;
-		case 47: goto st8;
-	}
-	goto st0;
-st6:
-	if ( ++p == pe )
-		goto _test_eof6;
-case 6:
-	if ( (*p) == 42 )
-		goto st7;
-	goto st6;
-st7:
-	if ( ++p == pe )
-		goto _test_eof7;
-case 7:
-	switch( (*p) ) {
-		case 42: goto st7;
-		case 47: goto st4;
-	}
-	goto st6;
-st8:
-	if ( ++p == pe )
-		goto _test_eof8;
-case 8:
-	if ( (*p) == 10 )
-		goto st4;
-	goto st8;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
@@ -1723,7 +1958,7 @@ st11:
 case 11:
 	switch( (*p) ) {
 		case 42: goto st11;
-		case 47: goto st3;
+		case 47: goto st8;
 	}
 	goto st10;
 st12:
@@ -1731,50 +1966,252 @@ st12:
 		goto _test_eof12;
 case 12:
 	if ( (*p) == 10 )
-		goto st3;
+		goto st8;
 	goto st12;
-tr4:
-#line 791 "parser.rl"
-	{ p--; {p++; cs = 17; goto _out;} }
-	goto st17;
-st17:
-	if ( ++p == pe )
-		goto _test_eof17;
-case 17:
-#line 1745 "parser.c"
-	goto st0;
 st13:
 	if ( ++p == pe )
 		goto _test_eof13;
 case 13:
-	switch( (*p) ) {
-		case 42: goto st14;
-		case 47: goto st16;
+	_widec = (*p);
+	if ( (*p) < 13 ) {
+		if ( (*p) > 9 ) {
+			if ( 10 <= (*p) && (*p) <= 10 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else if ( (*p) >= 9 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 13 ) {
+		if ( (*p) > 32 ) {
+			if ( 47 <= (*p) && (*p) <= 47 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else if ( (*p) >= 32 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
 	}
+	switch( _widec ) {
+		case 34: goto tr2;
+		case 45: goto tr2;
+		case 73: goto tr2;
+		case 78: goto tr2;
+		case 91: goto tr2;
+		case 93: goto tr4;
+		case 102: goto tr2;
+		case 110: goto tr2;
+		case 116: goto tr2;
+		case 123: goto tr2;
+		case 269: goto st8;
+		case 288: goto st8;
+		case 303: goto st9;
+		case 525: goto st13;
+		case 544: goto st13;
+		case 559: goto st14;
+	}
+	if ( _widec < 265 ) {
+		if ( 48 <= _widec && _widec <= 57 )
+			goto tr2;
+	} else if ( _widec > 266 ) {
+		if ( 521 <= _widec && _widec <= 522 )
+			goto st13;
+	} else
+		goto st8;
 	goto st0;
 st14:
 	if ( ++p == pe )
 		goto _test_eof14;
 case 14:
-	if ( (*p) == 42 )
-		goto st15;
-	goto st14;
+	_widec = (*p);
+	if ( (*p) > 42 ) {
+		if ( 47 <= (*p) && (*p) <= 47 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) >= 42 ) {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+	}
+	switch( _widec ) {
+		case 298: goto st10;
+		case 303: goto st12;
+		case 554: goto st15;
+		case 559: goto st17;
+	}
+	goto st0;
 st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-	switch( (*p) ) {
-		case 42: goto st15;
-		case 47: goto st2;
+	_widec = (*p);
+	if ( (*p) < 42 ) {
+		if ( (*p) <= 41 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 42 ) {
+		if ( 43 <= (*p) )
+ {			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
 	}
-	goto st14;
+	switch( _widec ) {
+		case 298: goto st11;
+		case 554: goto st16;
+	}
+	if ( _widec > 383 ) {
+		if ( 384 <= _widec && _widec <= 639 )
+			goto st15;
+	} else if ( _widec >= 128 )
+		goto st10;
+	goto st0;
 st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
+	_widec = (*p);
+	if ( (*p) < 43 ) {
+		if ( (*p) > 41 ) {
+			if ( 42 <= (*p) && (*p) <= 42 ) {
+				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 46 ) {
+		if ( (*p) > 47 ) {
+			if ( 48 <= (*p) )
+ {				_widec = (short)(128 + ((*p) - -128));
+				if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+			}
+		} else if ( (*p) >= 47 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+	}
+	switch( _widec ) {
+		case 298: goto st11;
+		case 303: goto st8;
+		case 554: goto st16;
+		case 559: goto st13;
+	}
+	if ( _widec > 383 ) {
+		if ( 384 <= _widec && _widec <= 639 )
+			goto st15;
+	} else if ( _widec >= 128 )
+		goto st10;
+	goto st0;
+st17:
+	if ( ++p == pe )
+		goto _test_eof17;
+case 17:
+	_widec = (*p);
+	if ( (*p) < 10 ) {
+		if ( (*p) <= 9 ) {
+			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else if ( (*p) > 10 ) {
+		if ( 11 <= (*p) )
+ {			_widec = (short)(128 + ((*p) - -128));
+			if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+		}
+	} else {
+		_widec = (short)(128 + ((*p) - -128));
+		if (
+#line 794 "parser.rl"
+ json->allow_trailing_comma  ) _widec += 256;
+	}
+	switch( _widec ) {
+		case 266: goto st8;
+		case 522: goto st13;
+	}
+	if ( _widec > 383 ) {
+		if ( 384 <= _widec && _widec <= 639 )
+			goto st17;
+	} else if ( _widec >= 128 )
+		goto st12;
+	goto st0;
+st18:
+	if ( ++p == pe )
+		goto _test_eof18;
+case 18:
+	switch( (*p) ) {
+		case 42: goto st19;
+		case 47: goto st21;
+	}
+	goto st0;
+st19:
+	if ( ++p == pe )
+		goto _test_eof19;
+case 19:
+	if ( (*p) == 42 )
+		goto st20;
+	goto st19;
+st20:
+	if ( ++p == pe )
+		goto _test_eof20;
+case 20:
+	switch( (*p) ) {
+		case 42: goto st20;
+		case 47: goto st2;
+	}
+	goto st19;
+st21:
+	if ( ++p == pe )
+		goto _test_eof21;
+case 21:
 	if ( (*p) == 10 )
 		goto st2;
-	goto st16;
+	goto st21;
 	}
 	_test_eof2: cs = 2; goto _test_eof;
 	_test_eof3: cs = 3; goto _test_eof;
@@ -1782,22 +2219,27 @@ case 16:
 	_test_eof5: cs = 5; goto _test_eof;
 	_test_eof6: cs = 6; goto _test_eof;
 	_test_eof7: cs = 7; goto _test_eof;
+	_test_eof22: cs = 22; goto _test_eof;
 	_test_eof8: cs = 8; goto _test_eof;
 	_test_eof9: cs = 9; goto _test_eof;
 	_test_eof10: cs = 10; goto _test_eof;
 	_test_eof11: cs = 11; goto _test_eof;
 	_test_eof12: cs = 12; goto _test_eof;
-	_test_eof17: cs = 17; goto _test_eof;
 	_test_eof13: cs = 13; goto _test_eof;
 	_test_eof14: cs = 14; goto _test_eof;
 	_test_eof15: cs = 15; goto _test_eof;
 	_test_eof16: cs = 16; goto _test_eof;
+	_test_eof17: cs = 17; goto _test_eof;
+	_test_eof18: cs = 18; goto _test_eof;
+	_test_eof19: cs = 19; goto _test_eof;
+	_test_eof20: cs = 20; goto _test_eof;
+	_test_eof21: cs = 21; goto _test_eof;
 
 	_test_eof: {}
 	_out: {}
 	}
 
-#line 812 "parser.rl"
+#line 817 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         long count = json->stack->head - stack_head;
@@ -1971,7 +2413,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
 }
 
 
-#line 1975 "parser.c"
+#line 2417 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -1979,7 +2421,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 1003 "parser.rl"
+#line 1008 "parser.rl"
 
 
 static int
@@ -2000,15 +2442,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 2004 "parser.c"
+#line 2446 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 1023 "parser.rl"
+#line 1028 "parser.rl"
     json->memo = p;
 
-#line 2012 "parser.c"
+#line 2454 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2033,7 +2475,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 990 "parser.rl"
+#line 995 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         if (NIL_P(*result)) {
@@ -2043,14 +2485,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 1000 "parser.rl"
+#line 1005 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 2054 "parser.c"
+#line 2496 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -2126,7 +2568,7 @@ case 7:
 	_out: {}
 	}
 
-#line 1025 "parser.rl"
+#line 1030 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -2178,16 +2620,17 @@ static int configure_parser_i(VALUE key, VALUE val, VALUE data)
 {
     JSON_Parser *json = (JSON_Parser *)data;
 
-         if (key == sym_max_nesting)       { json->max_nesting = RTEST(val) ? FIX2INT(val) : 0; }
-    else if (key == sym_allow_nan)         { json->allow_nan = RTEST(val); }
-    else if (key == sym_symbolize_names)   { json->symbolize_names = RTEST(val); }
-    else if (key == sym_freeze)            { json->freeze = RTEST(val); }
-    else if (key == sym_create_id)         { json->create_id = RTEST(val) ? val : Qfalse; }
-    else if (key == sym_object_class)      { json->object_class = RTEST(val) ? val : Qfalse; }
-    else if (key == sym_array_class)       { json->array_class = RTEST(val) ? val : Qfalse; }
-    else if (key == sym_decimal_class)     { json->decimal_class = RTEST(val) ? val : Qfalse; }
-    else if (key == sym_match_string)      { json->match_string = RTEST(val) ? val : Qfalse; }
-    else if (key == sym_create_additions)  {
+         if (key == sym_max_nesting)          { json->max_nesting = RTEST(val) ? FIX2INT(val) : 0; }
+    else if (key == sym_allow_nan)            { json->allow_nan = RTEST(val); }
+    else if (key == sym_allow_trailing_comma) { json->allow_trailing_comma = RTEST(val); }
+    else if (key == sym_symbolize_names)      { json->symbolize_names = RTEST(val); }
+    else if (key == sym_freeze)               { json->freeze = RTEST(val); }
+    else if (key == sym_create_id)            { json->create_id = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_object_class)         { json->object_class = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_array_class)          { json->array_class = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_decimal_class)        { json->decimal_class = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_match_string)         { json->match_string = RTEST(val) ? val : Qfalse; }
+    else if (key == sym_create_additions)     {
         if (NIL_P(val)) {
             json->create_additions = true;
             json->deprecated_create_additions = true;
@@ -2278,7 +2721,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 2282 "parser.c"
+#line 2725 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -2286,7 +2729,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 1190 "parser.rl"
+#line 1196 "parser.rl"
 
 
 /*
@@ -2315,16 +2758,16 @@ static VALUE cParser_parse(VALUE self)
     json->stack = &stack;
 
 
-#line 2319 "parser.c"
+#line 2762 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1218 "parser.rl"
+#line 1224 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2328 "parser.c"
+#line 2771 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2358,7 +2801,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1182 "parser.rl"
+#line 1188 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2368,7 +2811,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2372 "parser.c"
+#line 2815 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2457,7 +2900,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1221 "parser.rl"
+#line 1227 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -2493,16 +2936,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     json->stack = &stack;
 
 
-#line 2497 "parser.c"
+#line 2940 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1256 "parser.rl"
+#line 1262 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2506 "parser.c"
+#line 2949 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2536,7 +2979,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1182 "parser.rl"
+#line 1188 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2546,7 +2989,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2550 "parser.c"
+#line 2993 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2635,7 +3078,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1259 "parser.rl"
+#line 1265 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -2738,6 +3181,7 @@ void Init_parser(void)
 
     sym_max_nesting = ID2SYM(rb_intern("max_nesting"));
     sym_allow_nan = ID2SYM(rb_intern("allow_nan"));
+    sym_allow_trailing_comma = ID2SYM(rb_intern("allow_trailing_comma"));
     sym_symbolize_names = ID2SYM(rb_intern("symbolize_names"));
     sym_freeze = ID2SYM(rb_intern("freeze"));
     sym_create_additions = ID2SYM(rb_intern("create_additions"));

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -54,6 +54,7 @@ public class Parser extends RubyObject {
     private boolean deprecatedCreateAdditions;
     private int maxNesting;
     private boolean allowNaN;
+    private boolean allowTrailingComma;
     private boolean symbolizeNames;
     private boolean freeze;
     private RubyClass objectClass;
@@ -124,6 +125,11 @@ public class Parser extends RubyObject {
      * <code>Infinity</code> and <code>-Infinity</code> in defiance of RFC 4627
      * to be parsed by the Parser. This option defaults to <code>false</code>.
      *
+     * <dt><code>:allow_trailing_comma</code>
+     * <dd>If set to <code>true</code>, allow arrays and objects with a trailing
+     * comma in defiance of RFC 4627 to be parsed by the Parser.
+     * This option defaults to <code>false</code>.
+     *
      * <dt><code>:symbolize_names</code>
      * <dd>If set to <code>true</code>, returns symbols for the names (keys) in
      * a JSON object. Otherwise strings are returned, which is also the default.
@@ -177,6 +183,7 @@ public class Parser extends RubyObject {
         OptionsReader opts   = new OptionsReader(context, args.length > 1 ? args[1] : null);
         this.maxNesting      = opts.getInt("max_nesting", DEFAULT_MAX_NESTING);
         this.allowNaN        = opts.getBool("allow_nan", false);
+        this.allowTrailingComma = opts.getBool("allow_trailing_comma", false);
         this.symbolizeNames  = opts.getBool("symbolize_names", false);
         this.freeze          = opts.getBool("freeze", false);
         this.createId        = opts.getString("create_id", getCreateId(context));
@@ -364,11 +371,11 @@ public class Parser extends RubyObject {
         }
 
         
-// line 390 "Parser.rl"
+// line 397 "Parser.rl"
 
 
         
-// line 372 "Parser.java"
+// line 379 "Parser.java"
 private static byte[] init__JSON_value_actions_0()
 {
 	return new byte [] {
@@ -482,7 +489,7 @@ static final int JSON_value_error = 0;
 static final int JSON_value_en_main = 1;
 
 
-// line 496 "Parser.rl"
+// line 503 "Parser.rl"
 
 
         void parseValue(ParserResult res, int p, int pe) {
@@ -490,14 +497,14 @@ static final int JSON_value_en_main = 1;
             IRubyObject result = null;
 
             
-// line 494 "Parser.java"
+// line 501 "Parser.java"
 	{
 	cs = JSON_value_start;
 	}
 
-// line 503 "Parser.rl"
+// line 510 "Parser.rl"
             
-// line 501 "Parser.java"
+// line 508 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -523,13 +530,13 @@ case 1:
 	while ( _nacts-- > 0 ) {
 		switch ( _JSON_value_actions[_acts++] ) {
 	case 9:
-// line 481 "Parser.rl"
+// line 488 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 533 "Parser.java"
+// line 540 "Parser.java"
 		}
 	}
 
@@ -592,25 +599,25 @@ case 1:
 			switch ( _JSON_value_actions[_acts++] )
 			{
 	case 0:
-// line 398 "Parser.rl"
+// line 405 "Parser.rl"
 	{
                 result = getRuntime().getNil();
             }
 	break;
 	case 1:
-// line 401 "Parser.rl"
+// line 408 "Parser.rl"
 	{
                 result = getRuntime().getFalse();
             }
 	break;
 	case 2:
-// line 404 "Parser.rl"
+// line 411 "Parser.rl"
 	{
                 result = getRuntime().getTrue();
             }
 	break;
 	case 3:
-// line 407 "Parser.rl"
+// line 414 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_NAN);
@@ -620,7 +627,7 @@ case 1:
             }
 	break;
 	case 4:
-// line 414 "Parser.rl"
+// line 421 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_INFINITY);
@@ -630,7 +637,7 @@ case 1:
             }
 	break;
 	case 5:
-// line 421 "Parser.rl"
+// line 428 "Parser.rl"
 	{
                 if (pe > p + 8 &&
                     absSubSequence(p, p + 9).equals(JSON_MINUS_INFINITY)) {
@@ -659,7 +666,7 @@ case 1:
             }
 	break;
 	case 6:
-// line 447 "Parser.rl"
+// line 454 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -672,7 +679,7 @@ case 1:
             }
 	break;
 	case 7:
-// line 457 "Parser.rl"
+// line 464 "Parser.rl"
 	{
                 currentNesting++;
                 parseArray(res, p, pe);
@@ -687,7 +694,7 @@ case 1:
             }
 	break;
 	case 8:
-// line 469 "Parser.rl"
+// line 476 "Parser.rl"
 	{
                 currentNesting++;
                 parseObject(res, p, pe);
@@ -701,7 +708,7 @@ case 1:
                 }
             }
 	break;
-// line 705 "Parser.java"
+// line 712 "Parser.java"
 			}
 		}
 	}
@@ -721,7 +728,7 @@ case 5:
 	break; }
 	}
 
-// line 504 "Parser.rl"
+// line 511 "Parser.rl"
 
             if (cs >= JSON_value_first_final && result != null) {
                 if (parser.freeze) {
@@ -734,7 +741,7 @@ case 5:
         }
 
         
-// line 738 "Parser.java"
+// line 745 "Parser.java"
 private static byte[] init__JSON_integer_actions_0()
 {
 	return new byte [] {
@@ -833,7 +840,7 @@ static final int JSON_integer_error = 0;
 static final int JSON_integer_en_main = 1;
 
 
-// line 526 "Parser.rl"
+// line 533 "Parser.rl"
 
 
         void parseInteger(ParserResult res, int p, int pe) {
@@ -851,15 +858,15 @@ static final int JSON_integer_en_main = 1;
             int cs = EVIL;
 
             
-// line 855 "Parser.java"
+// line 862 "Parser.java"
 	{
 	cs = JSON_integer_start;
 	}
 
-// line 543 "Parser.rl"
+// line 550 "Parser.rl"
             int memo = p;
             
-// line 863 "Parser.java"
+// line 870 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -940,13 +947,13 @@ case 1:
 			switch ( _JSON_integer_actions[_acts++] )
 			{
 	case 0:
-// line 520 "Parser.rl"
+// line 527 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 950 "Parser.java"
+// line 957 "Parser.java"
 			}
 		}
 	}
@@ -966,7 +973,7 @@ case 5:
 	break; }
 	}
 
-// line 545 "Parser.rl"
+// line 552 "Parser.rl"
 
             if (cs < JSON_integer_first_final) {
                 return -1;
@@ -986,7 +993,7 @@ case 5:
         }
 
         
-// line 990 "Parser.java"
+// line 997 "Parser.java"
 private static byte[] init__JSON_float_actions_0()
 {
 	return new byte [] {
@@ -1088,7 +1095,7 @@ static final int JSON_float_error = 0;
 static final int JSON_float_en_main = 1;
 
 
-// line 578 "Parser.rl"
+// line 585 "Parser.rl"
 
 
         void parseFloat(ParserResult res, int p, int pe) {
@@ -1107,15 +1114,15 @@ static final int JSON_float_en_main = 1;
             int cs = EVIL;
 
             
-// line 1111 "Parser.java"
+// line 1118 "Parser.java"
 	{
 	cs = JSON_float_start;
 	}
 
-// line 596 "Parser.rl"
+// line 603 "Parser.rl"
             int memo = p;
             
-// line 1119 "Parser.java"
+// line 1126 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1196,13 +1203,13 @@ case 1:
 			switch ( _JSON_float_actions[_acts++] )
 			{
 	case 0:
-// line 569 "Parser.rl"
+// line 576 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1206 "Parser.java"
+// line 1213 "Parser.java"
 			}
 		}
 	}
@@ -1222,7 +1229,7 @@ case 5:
 	break; }
 	}
 
-// line 598 "Parser.rl"
+// line 605 "Parser.rl"
 
             if (cs < JSON_float_first_final) {
                 return -1;
@@ -1232,7 +1239,7 @@ case 5:
         }
 
         
-// line 1236 "Parser.java"
+// line 1243 "Parser.java"
 private static byte[] init__JSON_string_actions_0()
 {
 	return new byte [] {
@@ -1334,7 +1341,7 @@ static final int JSON_string_error = 0;
 static final int JSON_string_en_main = 1;
 
 
-// line 637 "Parser.rl"
+// line 644 "Parser.rl"
 
 
         void parseString(ParserResult res, int p, int pe) {
@@ -1342,15 +1349,15 @@ static final int JSON_string_en_main = 1;
             IRubyObject result = null;
 
             
-// line 1346 "Parser.java"
+// line 1353 "Parser.java"
 	{
 	cs = JSON_string_start;
 	}
 
-// line 644 "Parser.rl"
+// line 651 "Parser.rl"
             int memo = p;
             
-// line 1354 "Parser.java"
+// line 1361 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1431,7 +1438,7 @@ case 1:
 			switch ( _JSON_string_actions[_acts++] )
 			{
 	case 0:
-// line 612 "Parser.rl"
+// line 619 "Parser.rl"
 	{
                 int offset = byteList.begin();
                 ByteList decoded = decoder.decode(byteList, memo + 1 - offset,
@@ -1446,13 +1453,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 625 "Parser.rl"
+// line 632 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1456 "Parser.java"
+// line 1463 "Parser.java"
 			}
 		}
 	}
@@ -1472,7 +1479,7 @@ case 5:
 	break; }
 	}
 
-// line 646 "Parser.rl"
+// line 653 "Parser.rl"
 
             if (parser.createAdditions) {
                 RubyHash matchString = parser.match_string;
@@ -1520,7 +1527,7 @@ case 5:
         }
 
         
-// line 1524 "Parser.java"
+// line 1531 "Parser.java"
 private static byte[] init__JSON_array_actions_0()
 {
 	return new byte [] {
@@ -1531,36 +1538,86 @@ private static byte[] init__JSON_array_actions_0()
 private static final byte _JSON_array_actions[] = init__JSON_array_actions_0();
 
 
+private static byte[] init__JSON_array_cond_offsets_0()
+{
+	return new byte [] {
+	    0,    0,    0,    0,    1,    1,    1,    1,    1,    1,    1,    1,
+	    1,    1,    6,    6,    6,    6,    6,    8,   11,   16,   19
+	};
+}
+
+private static final byte _JSON_array_cond_offsets[] = init__JSON_array_cond_offsets_0();
+
+
+private static byte[] init__JSON_array_cond_lengths_0()
+{
+	return new byte [] {
+	    0,    0,    0,    1,    0,    0,    0,    0,    0,    0,    0,    0,
+	    0,    5,    0,    0,    0,    0,    2,    3,    5,    3,    0
+	};
+}
+
+private static final byte _JSON_array_cond_lengths[] = init__JSON_array_cond_lengths_0();
+
+
+private static int[] init__JSON_array_cond_keys_0()
+{
+	return new int [] {
+	   44,   44,    9,    9,   10,   10,   13,   13,   32,   32,   47,   47,
+	   42,   42,   47,   47,    0,   41,   42,   42,   43,65535,    0,   41,
+	   42,   42,   43,   46,   47,   47,   48,65535,    0,    9,   10,   10,
+	   11,65535,    0
+	};
+}
+
+private static final int _JSON_array_cond_keys[] = init__JSON_array_cond_keys_0();
+
+
+private static byte[] init__JSON_array_cond_spaces_0()
+{
+	return new byte [] {
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	    0,    0,    0,    0,    0,    0,    0,    0
+	};
+}
+
+private static final byte _JSON_array_cond_spaces[] = init__JSON_array_cond_spaces_0();
+
+
 private static byte[] init__JSON_array_key_offsets_0()
 {
 	return new byte [] {
-	    0,    0,    1,   18,   25,   41,   43,   44,   46,   47,   49,   50,
-	   52,   53,   55,   56,   58,   59
+	    0,    0,    1,   18,   26,   28,   29,   31,   32,   48,   50,   51,
+	   53,   54,   76,   78,   79,   81,   82,   86,   92,  100,  106
 	};
 }
 
 private static final byte _JSON_array_key_offsets[] = init__JSON_array_key_offsets_0();
 
 
-private static char[] init__JSON_array_trans_keys_0()
+private static int[] init__JSON_array_trans_keys_0()
 {
-	return new char [] {
+	return new int [] {
 	   91,   13,   32,   34,   45,   47,   73,   78,   91,   93,  102,  110,
-	  116,  123,    9,   10,   48,   57,   13,   32,   44,   47,   93,    9,
-	   10,   13,   32,   34,   45,   47,   73,   78,   91,  102,  110,  116,
-	  123,    9,   10,   48,   57,   42,   47,   42,   42,   47,   10,   42,
-	   47,   42,   42,   47,   10,   42,   47,   42,   42,   47,   10,    0
+	  116,  123,    9,   10,   48,   57,   13,   32,   47,   93,65580,131116,
+	    9,   10,   42,   47,   42,   42,   47,   10,   13,   32,   34,   45,
+	   47,   73,   78,   91,  102,  110,  116,  123,    9,   10,   48,   57,
+	   42,   47,   42,   42,   47,   10,   34,   45,   73,   78,   91,   93,
+	  102,  110,  116,  123,65549,65568,65583,131085,131104,131119,   48,   57,
+	65545,65546,131081,131082,   42,   47,   42,   42,   47,   10,65578,65583,
+	131114,131119,65578,131114,65536,131071,131072,196607,65578,65583,131114,131119,
+	65536,131071,131072,196607,65546,131082,65536,131071,131072,196607,    0
 	};
 }
 
-private static final char _JSON_array_trans_keys[] = init__JSON_array_trans_keys_0();
+private static final int _JSON_array_trans_keys[] = init__JSON_array_trans_keys_0();
 
 
 private static byte[] init__JSON_array_single_lengths_0()
 {
 	return new byte [] {
-	    0,    1,   13,    5,   12,    2,    1,    2,    1,    2,    1,    2,
-	    1,    2,    1,    2,    1,    0
+	    0,    1,   13,    6,    2,    1,    2,    1,   12,    2,    1,    2,
+	    1,   16,    2,    1,    2,    1,    4,    2,    4,    2,    0
 	};
 }
 
@@ -1570,34 +1627,38 @@ private static final byte _JSON_array_single_lengths[] = init__JSON_array_single
 private static byte[] init__JSON_array_range_lengths_0()
 {
 	return new byte [] {
-	    0,    0,    2,    1,    2,    0,    0,    0,    0,    0,    0,    0,
-	    0,    0,    0,    0,    0,    0
+	    0,    0,    2,    1,    0,    0,    0,    0,    2,    0,    0,    0,
+	    0,    3,    0,    0,    0,    0,    0,    2,    2,    2,    0
 	};
 }
 
 private static final byte _JSON_array_range_lengths[] = init__JSON_array_range_lengths_0();
 
 
-private static byte[] init__JSON_array_index_offsets_0()
+private static short[] init__JSON_array_index_offsets_0()
 {
-	return new byte [] {
-	    0,    0,    2,   18,   25,   40,   43,   45,   48,   50,   53,   55,
-	   58,   60,   63,   65,   68,   70
+	return new short [] {
+	    0,    0,    2,   18,   26,   29,   31,   34,   36,   51,   54,   56,
+	   59,   61,   81,   84,   86,   89,   91,   96,  101,  108,  113
 	};
 }
 
-private static final byte _JSON_array_index_offsets[] = init__JSON_array_index_offsets_0();
+private static final short _JSON_array_index_offsets[] = init__JSON_array_index_offsets_0();
 
 
 private static byte[] init__JSON_array_indicies_0()
 {
 	return new byte [] {
 	    0,    1,    0,    0,    2,    2,    3,    2,    2,    2,    4,    2,
-	    2,    2,    2,    0,    2,    1,    5,    5,    6,    7,    4,    5,
-	    1,    6,    6,    2,    2,    8,    2,    2,    2,    2,    2,    2,
-	    2,    6,    2,    1,    9,   10,    1,   11,    9,   11,    6,    9,
-	    6,   10,   12,   13,    1,   14,   12,   14,    5,   12,    5,   13,
-	   15,   16,    1,   17,   15,   17,    0,   15,    0,   16,    1,    0
+	    2,    2,    2,    0,    2,    1,    5,    5,    6,    4,    7,    8,
+	    5,    1,    9,   10,    1,   11,    9,   11,    5,    9,    5,   10,
+	    7,    7,    2,    2,   12,    2,    2,    2,    2,    2,    2,    2,
+	    7,    2,    1,   13,   14,    1,   15,   13,   15,    7,   13,    7,
+	   14,    2,    2,    2,    2,    2,    4,    2,    2,    2,    2,    0,
+	    0,    3,    8,    8,   16,    2,    0,    8,    1,   17,   18,    1,
+	   19,   17,   19,    0,   17,    0,   18,   17,   18,   20,   21,    1,
+	   19,   22,   17,   20,    1,   19,    0,   22,    8,   17,   20,    1,
+	    0,    8,   18,   21,    1,    1,    0
 	};
 }
 
@@ -1607,8 +1668,8 @@ private static final byte _JSON_array_indicies[] = init__JSON_array_indicies_0()
 private static byte[] init__JSON_array_trans_targs_0()
 {
 	return new byte [] {
-	    2,    0,    3,   13,   17,    3,    4,    9,    5,    6,    8,    7,
-	   10,   12,   11,   14,   16,   15
+	    2,    0,    3,   14,   22,    3,    4,    8,   13,    5,    7,    6,
+	    9,   10,   12,   11,   18,   15,   17,   16,   19,   21,   20
 	};
 }
 
@@ -1619,7 +1680,7 @@ private static byte[] init__JSON_array_trans_actions_0()
 {
 	return new byte [] {
 	    0,    0,    1,    0,    3,    0,    0,    0,    0,    0,    0,    0,
-	    0,    0,    0,    0,    0,    0
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0
 	};
 }
 
@@ -1627,13 +1688,13 @@ private static final byte _JSON_array_trans_actions[] = init__JSON_array_trans_a
 
 
 static final int JSON_array_start = 1;
-static final int JSON_array_first_final = 17;
+static final int JSON_array_first_final = 22;
 static final int JSON_array_error = 0;
 
 static final int JSON_array_en_main = 1;
 
 
-// line 729 "Parser.rl"
+// line 738 "Parser.rl"
 
 
         void parseArray(ParserResult res, int p, int pe) {
@@ -1653,17 +1714,18 @@ static final int JSON_array_en_main = 1;
             }
 
             
-// line 1657 "Parser.java"
+// line 1718 "Parser.java"
 	{
 	cs = JSON_array_start;
 	}
 
-// line 748 "Parser.rl"
+// line 757 "Parser.rl"
             
-// line 1664 "Parser.java"
+// line 1725 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
+	int _widec;
 	int _acts;
 	int _nacts;
 	int _keys;
@@ -1681,6 +1743,37 @@ static final int JSON_array_en_main = 1;
 		continue _goto;
 	}
 case 1:
+	_widec = data[p];
+	_keys = _JSON_array_cond_offsets[cs]*2
+;	_klen = _JSON_array_cond_lengths[cs];
+	if ( _klen > 0 ) {
+		int _lower = _keys
+;		int _mid;
+		int _upper = _keys + (_klen<<1) - 2;
+		while (true) {
+			if ( _upper < _lower )
+				break;
+
+			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
+			if ( _widec < _JSON_array_cond_keys[_mid] )
+				_upper = _mid - 2;
+			else if ( _widec > _JSON_array_cond_keys[_mid+1] )
+				_lower = _mid + 2;
+			else {
+				switch ( _JSON_array_cond_spaces[_JSON_array_cond_offsets[cs] + ((_mid - _keys)>>1)] ) {
+	case 0: {
+		_widec = 65536 + (data[p] - 0);
+		if ( 
+// line 705 "Parser.rl"
+ parser.allowTrailingComma  ) _widec += 65536;
+		break;
+	}
+				}
+				break;
+			}
+		}
+	}
+
 	_match: do {
 	_keys = _JSON_array_key_offsets[cs];
 	_trans = _JSON_array_index_offsets[cs];
@@ -1694,9 +1787,9 @@ case 1:
 				break;
 
 			_mid = _lower + ((_upper-_lower) >> 1);
-			if ( data[p] < _JSON_array_trans_keys[_mid] )
+			if ( _widec < _JSON_array_trans_keys[_mid] )
 				_upper = _mid - 1;
-			else if ( data[p] > _JSON_array_trans_keys[_mid] )
+			else if ( _widec > _JSON_array_trans_keys[_mid] )
 				_lower = _mid + 1;
 			else {
 				_trans += (_mid - _keys);
@@ -1717,9 +1810,9 @@ case 1:
 				break;
 
 			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
-			if ( data[p] < _JSON_array_trans_keys[_mid] )
+			if ( _widec < _JSON_array_trans_keys[_mid] )
 				_upper = _mid - 2;
-			else if ( data[p] > _JSON_array_trans_keys[_mid+1] )
+			else if ( _widec > _JSON_array_trans_keys[_mid+1] )
 				_lower = _mid + 2;
 			else {
 				_trans += ((_mid - _keys)>>1);
@@ -1741,7 +1834,7 @@ case 1:
 			switch ( _JSON_array_actions[_acts++] )
 			{
 	case 0:
-// line 698 "Parser.rl"
+// line 707 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1758,13 +1851,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 713 "Parser.rl"
+// line 722 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1768 "Parser.java"
+// line 1861 "Parser.java"
 			}
 		}
 	}
@@ -1784,7 +1877,7 @@ case 5:
 	break; }
 	}
 
-// line 749 "Parser.rl"
+// line 758 "Parser.rl"
 
             if (cs >= JSON_array_first_final) {
                 res.update(result, p + 1);
@@ -1794,7 +1887,7 @@ case 5:
         }
 
         
-// line 1798 "Parser.java"
+// line 1891 "Parser.java"
 private static byte[] init__JSON_object_actions_0()
 {
 	return new byte [] {
@@ -1805,40 +1898,91 @@ private static byte[] init__JSON_object_actions_0()
 private static final byte _JSON_object_actions[] = init__JSON_object_actions_0();
 
 
+private static byte[] init__JSON_object_cond_offsets_0()
+{
+	return new byte [] {
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    6,    6,
+	    6,    6,    6,    6,    6,    6,    6,    6,    6,    8,   11,   16,
+	   19,   19,   19,   19,   19,   19,   19,   19,   19
+	};
+}
+
+private static final byte _JSON_object_cond_offsets[] = init__JSON_object_cond_offsets_0();
+
+
+private static byte[] init__JSON_object_cond_lengths_0()
+{
+	return new byte [] {
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    6,    0,    0,
+	    0,    0,    0,    0,    0,    0,    0,    0,    2,    3,    5,    3,
+	    0,    0,    0,    0,    0,    0,    0,    0,    0
+	};
+}
+
+private static final byte _JSON_object_cond_lengths[] = init__JSON_object_cond_lengths_0();
+
+
+private static int[] init__JSON_object_cond_keys_0()
+{
+	return new int [] {
+	    9,    9,   10,   10,   13,   13,   32,   32,   44,   44,   47,   47,
+	   42,   42,   47,   47,    0,   41,   42,   42,   43,65535,    0,   41,
+	   42,   42,   43,   46,   47,   47,   48,65535,    0,    9,   10,   10,
+	   11,65535,    0
+	};
+}
+
+private static final int _JSON_object_cond_keys[] = init__JSON_object_cond_keys_0();
+
+
+private static byte[] init__JSON_object_cond_spaces_0()
+{
+	return new byte [] {
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	    0,    0,    0,    0,    0,    0,    0,    0
+	};
+}
+
+private static final byte _JSON_object_cond_spaces[] = init__JSON_object_cond_spaces_0();
+
+
 private static byte[] init__JSON_object_key_offsets_0()
 {
 	return new byte [] {
-	    0,    0,    1,    8,   14,   16,   17,   19,   20,   36,   43,   49,
-	   51,   52,   54,   55,   57,   58,   60,   61,   63,   64,   66,   67,
-	   69,   70,   72,   73
+	    0,    0,    1,    8,   14,   16,   17,   19,   20,   36,   49,   56,
+	   62,   64,   65,   67,   68,   70,   71,   73,   74,   78,   84,   92,
+	   98,  100,  101,  103,  104,  106,  107,  109,  110
 	};
 }
 
 private static final byte _JSON_object_key_offsets[] = init__JSON_object_key_offsets_0();
 
 
-private static char[] init__JSON_object_trans_keys_0()
+private static int[] init__JSON_object_trans_keys_0()
 {
-	return new char [] {
+	return new int [] {
 	  123,   13,   32,   34,   47,  125,    9,   10,   13,   32,   47,   58,
 	    9,   10,   42,   47,   42,   42,   47,   10,   13,   32,   34,   45,
 	   47,   73,   78,   91,  102,  110,  116,  123,    9,   10,   48,   57,
-	   13,   32,   44,   47,  125,    9,   10,   13,   32,   34,   47,    9,
-	   10,   42,   47,   42,   42,   47,   10,   42,   47,   42,   42,   47,
-	   10,   42,   47,   42,   42,   47,   10,   42,   47,   42,   42,   47,
-	   10,    0
+	  125,65549,65568,65580,65583,131085,131104,131116,131119,65545,65546,131081,
+	131082,   13,   32,   44,   47,  125,    9,   10,   13,   32,   34,   47,
+	    9,   10,   42,   47,   42,   42,   47,   10,   42,   47,   42,   42,
+	   47,   10,65578,65583,131114,131119,65578,131114,65536,131071,131072,196607,
+	65578,65583,131114,131119,65536,131071,131072,196607,65546,131082,65536,131071,
+	131072,196607,   42,   47,   42,   42,   47,   10,   42,   47,   42,   42,
+	   47,   10,    0
 	};
 }
 
-private static final char _JSON_object_trans_keys[] = init__JSON_object_trans_keys_0();
+private static final int _JSON_object_trans_keys[] = init__JSON_object_trans_keys_0();
 
 
 private static byte[] init__JSON_object_single_lengths_0()
 {
 	return new byte [] {
-	    0,    1,    5,    4,    2,    1,    2,    1,   12,    5,    4,    2,
-	    1,    2,    1,    2,    1,    2,    1,    2,    1,    2,    1,    2,
-	    1,    2,    1,    0
+	    0,    1,    5,    4,    2,    1,    2,    1,   12,    9,    5,    4,
+	    2,    1,    2,    1,    2,    1,    2,    1,    4,    2,    4,    2,
+	    2,    1,    2,    1,    2,    1,    2,    1,    0
 	};
 }
 
@@ -1848,25 +1992,25 @@ private static final byte _JSON_object_single_lengths[] = init__JSON_object_sing
 private static byte[] init__JSON_object_range_lengths_0()
 {
 	return new byte [] {
-	    0,    0,    1,    1,    0,    0,    0,    0,    2,    1,    1,    0,
-	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-	    0,    0,    0,    0
+	    0,    0,    1,    1,    0,    0,    0,    0,    2,    2,    1,    1,
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    2,    2,    2,
+	    0,    0,    0,    0,    0,    0,    0,    0,    0
 	};
 }
 
 private static final byte _JSON_object_range_lengths[] = init__JSON_object_range_lengths_0();
 
 
-private static byte[] init__JSON_object_index_offsets_0()
+private static short[] init__JSON_object_index_offsets_0()
 {
-	return new byte [] {
-	    0,    0,    2,    9,   15,   18,   20,   23,   25,   40,   47,   53,
-	   56,   58,   61,   63,   66,   68,   71,   73,   76,   78,   81,   83,
-	   86,   88,   91,   93
+	return new short [] {
+	    0,    0,    2,    9,   15,   18,   20,   23,   25,   40,   52,   59,
+	   65,   68,   70,   73,   75,   78,   80,   83,   85,   90,   95,  102,
+	  107,  110,  112,  115,  117,  120,  122,  125,  127
 	};
 }
 
-private static final byte _JSON_object_index_offsets[] = init__JSON_object_index_offsets_0();
+private static final short _JSON_object_index_offsets[] = init__JSON_object_index_offsets_0();
 
 
 private static byte[] init__JSON_object_indicies_0()
@@ -1875,11 +2019,14 @@ private static byte[] init__JSON_object_indicies_0()
 	    0,    1,    0,    0,    2,    3,    4,    0,    1,    5,    5,    6,
 	    7,    5,    1,    8,    9,    1,   10,    8,   10,    5,    8,    5,
 	    9,    7,    7,   11,   11,   12,   11,   11,   11,   11,   11,   11,
-	   11,    7,   11,    1,   13,   13,   14,   15,    4,   13,    1,   14,
-	   14,    2,   16,   14,    1,   17,   18,    1,   19,   17,   19,   14,
-	   17,   14,   18,   20,   21,    1,   22,   20,   22,   13,   20,   13,
-	   21,   23,   24,    1,   25,   23,   25,    7,   23,    7,   24,   26,
-	   27,    1,   28,   26,   28,    0,   26,    0,   27,    1,    0
+	   11,    7,   11,    1,    4,   13,   13,   14,   15,   16,   16,    0,
+	   17,   13,   16,    1,   13,   13,   14,   15,    4,   13,    1,   14,
+	   14,    2,   18,   14,    1,   19,   20,    1,   21,   19,   21,   14,
+	   19,   14,   20,   22,   23,    1,   24,   22,   24,   13,   22,   13,
+	   23,   22,   23,   25,   26,    1,   24,   27,   22,   25,    1,   24,
+	   13,   27,   16,   22,   25,    1,   13,   16,   23,   26,    1,   28,
+	   29,    1,   30,   28,   30,    7,   28,    7,   29,   31,   32,    1,
+	   33,   31,   33,    0,   31,    0,   32,    1,    0
 	};
 }
 
@@ -1889,9 +2036,9 @@ private static final byte _JSON_object_indicies[] = init__JSON_object_indicies_0
 private static byte[] init__JSON_object_trans_targs_0()
 {
 	return new byte [] {
-	    2,    0,    3,   23,   27,    3,    4,    8,    5,    7,    6,    9,
-	   19,    9,   10,   15,   11,   12,   14,   13,   16,   18,   17,   20,
-	   22,   21,   24,   26,   25
+	    2,    0,    3,   28,   32,    3,    4,    8,    5,    7,    6,    9,
+	   24,   10,   11,   16,    9,   20,   12,   13,   15,   14,   17,   19,
+	   18,   21,   23,   22,   25,   27,   26,   29,   31,   30
 	};
 }
 
@@ -1903,7 +2050,7 @@ private static byte[] init__JSON_object_trans_actions_0()
 	return new byte [] {
 	    0,    0,    3,    0,    5,    0,    0,    0,    0,    0,    0,    1,
 	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-	    0,    0,    0,    0,    0
+	    0,    0,    0,    0,    0,    0,    0,    0,    0,    0
 	};
 }
 
@@ -1911,13 +2058,13 @@ private static final byte _JSON_object_trans_actions[] = init__JSON_object_trans
 
 
 static final int JSON_object_start = 1;
-static final int JSON_object_first_final = 27;
+static final int JSON_object_first_final = 32;
 static final int JSON_object_error = 0;
 
 static final int JSON_object_en_main = 1;
 
 
-// line 806 "Parser.rl"
+// line 819 "Parser.rl"
 
 
         void parseObject(ParserResult res, int p, int pe) {
@@ -1942,17 +2089,18 @@ static final int JSON_object_en_main = 1;
             }
 
             
-// line 1946 "Parser.java"
+// line 2093 "Parser.java"
 	{
 	cs = JSON_object_start;
 	}
 
-// line 830 "Parser.rl"
+// line 843 "Parser.rl"
             
-// line 1953 "Parser.java"
+// line 2100 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
+	int _widec;
 	int _acts;
 	int _nacts;
 	int _keys;
@@ -1970,6 +2118,37 @@ static final int JSON_object_en_main = 1;
 		continue _goto;
 	}
 case 1:
+	_widec = data[p];
+	_keys = _JSON_object_cond_offsets[cs]*2
+;	_klen = _JSON_object_cond_lengths[cs];
+	if ( _klen > 0 ) {
+		int _lower = _keys
+;		int _mid;
+		int _upper = _keys + (_klen<<1) - 2;
+		while (true) {
+			if ( _upper < _lower )
+				break;
+
+			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
+			if ( _widec < _JSON_object_cond_keys[_mid] )
+				_upper = _mid - 2;
+			else if ( _widec > _JSON_object_cond_keys[_mid+1] )
+				_lower = _mid + 2;
+			else {
+				switch ( _JSON_object_cond_spaces[_JSON_object_cond_offsets[cs] + ((_mid - _keys)>>1)] ) {
+	case 0: {
+		_widec = 65536 + (data[p] - 0);
+		if ( 
+// line 772 "Parser.rl"
+ parser.allowTrailingComma  ) _widec += 65536;
+		break;
+	}
+				}
+				break;
+			}
+		}
+	}
+
 	_match: do {
 	_keys = _JSON_object_key_offsets[cs];
 	_trans = _JSON_object_index_offsets[cs];
@@ -1983,9 +2162,9 @@ case 1:
 				break;
 
 			_mid = _lower + ((_upper-_lower) >> 1);
-			if ( data[p] < _JSON_object_trans_keys[_mid] )
+			if ( _widec < _JSON_object_trans_keys[_mid] )
 				_upper = _mid - 1;
-			else if ( data[p] > _JSON_object_trans_keys[_mid] )
+			else if ( _widec > _JSON_object_trans_keys[_mid] )
 				_lower = _mid + 1;
 			else {
 				_trans += (_mid - _keys);
@@ -2006,9 +2185,9 @@ case 1:
 				break;
 
 			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
-			if ( data[p] < _JSON_object_trans_keys[_mid] )
+			if ( _widec < _JSON_object_trans_keys[_mid] )
 				_upper = _mid - 2;
-			else if ( data[p] > _JSON_object_trans_keys[_mid+1] )
+			else if ( _widec > _JSON_object_trans_keys[_mid+1] )
 				_lower = _mid + 2;
 			else {
 				_trans += ((_mid - _keys)>>1);
@@ -2030,7 +2209,7 @@ case 1:
 			switch ( _JSON_object_actions[_acts++] )
 			{
 	case 0:
-// line 763 "Parser.rl"
+// line 774 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2047,7 +2226,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 778 "Parser.rl"
+// line 789 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -2065,13 +2244,13 @@ case 1:
             }
 	break;
 	case 2:
-// line 794 "Parser.rl"
+// line 805 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 2075 "Parser.java"
+// line 2254 "Parser.java"
 			}
 		}
 	}
@@ -2091,7 +2270,7 @@ case 5:
 	break; }
 	}
 
-// line 831 "Parser.rl"
+// line 844 "Parser.rl"
 
             if (cs < JSON_object_first_final) {
                 res.update(null, p + 1);
@@ -2127,7 +2306,7 @@ case 5:
         }
 
         
-// line 2131 "Parser.java"
+// line 2310 "Parser.java"
 private static byte[] init__JSON_actions_0()
 {
 	return new byte [] {
@@ -2230,7 +2409,7 @@ static final int JSON_error = 0;
 static final int JSON_en_main = 1;
 
 
-// line 885 "Parser.rl"
+// line 898 "Parser.rl"
 
 
         public IRubyObject parseImplemetation() {
@@ -2240,16 +2419,16 @@ static final int JSON_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2244 "Parser.java"
+// line 2423 "Parser.java"
 	{
 	cs = JSON_start;
 	}
 
-// line 894 "Parser.rl"
+// line 907 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2253 "Parser.java"
+// line 2432 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2330,7 +2509,7 @@ case 1:
 			switch ( _JSON_actions[_acts++] )
 			{
 	case 0:
-// line 871 "Parser.rl"
+// line 884 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2342,7 +2521,7 @@ case 1:
                 }
             }
 	break;
-// line 2346 "Parser.java"
+// line 2525 "Parser.java"
 			}
 		}
 	}
@@ -2362,7 +2541,7 @@ case 5:
 	break; }
 	}
 
-// line 897 "Parser.rl"
+// line 910 "Parser.rl"
 
             if (cs >= JSON_first_final && p == pe) {
                 return result;

--- a/java/src/json/ext/Parser.rl
+++ b/java/src/json/ext/Parser.rl
@@ -52,6 +52,7 @@ public class Parser extends RubyObject {
     private boolean deprecatedCreateAdditions;
     private int maxNesting;
     private boolean allowNaN;
+    private boolean allowTrailingComma;
     private boolean symbolizeNames;
     private boolean freeze;
     private RubyClass objectClass;
@@ -122,6 +123,11 @@ public class Parser extends RubyObject {
      * <code>Infinity</code> and <code>-Infinity</code> in defiance of RFC 4627
      * to be parsed by the Parser. This option defaults to <code>false</code>.
      *
+     * <dt><code>:allow_trailing_comma</code>
+     * <dd>If set to <code>true</code>, allow arrays and objects with a trailing
+     * comma in defiance of RFC 4627 to be parsed by the Parser.
+     * This option defaults to <code>false</code>.
+     *
      * <dt><code>:symbolize_names</code>
      * <dd>If set to <code>true</code>, returns symbols for the names (keys) in
      * a JSON object. Otherwise strings are returned, which is also the default.
@@ -175,6 +181,7 @@ public class Parser extends RubyObject {
         OptionsReader opts   = new OptionsReader(context, args.length > 1 ? args[1] : null);
         this.maxNesting      = opts.getInt("max_nesting", DEFAULT_MAX_NESTING);
         this.allowNaN        = opts.getBool("allow_nan", false);
+        this.allowTrailingComma = opts.getBool("allow_trailing_comma", false);
         this.symbolizeNames  = opts.getBool("symbolize_names", false);
         this.freeze          = opts.getBool("freeze", false);
         this.createId        = opts.getString("create_id", getCreateId(context));
@@ -695,6 +702,8 @@ public class Parser extends RubyObject {
 
             write data;
 
+            action allow_trailing_comma { parser.allowTrailingComma }
+
             action parse_value {
                 parseValue(res, fpc, pe);
                 if (res.result == null) {
@@ -723,7 +732,7 @@ public class Parser extends RubyObject {
                         ignore* )
                       ( ignore*
                         next_element
-                        ignore* )* )?
+                        ignore* )* ( (value_separator ignore*) when allow_trailing_comma )? )?
                     ignore*
                     end_array @exit;
         }%%
@@ -759,6 +768,8 @@ public class Parser extends RubyObject {
             include JSON_common;
 
             write data;
+
+            action allow_trailing_comma { parser.allowTrailingComma }
 
             action parse_value {
                 parseValue(res, fpc, pe);
@@ -801,7 +812,9 @@ public class Parser extends RubyObject {
             next_pair = ignore* value_separator pair;
 
             main := (
-              begin_object (pair (next_pair)*)? ignore* end_object
+                begin_object
+                (pair (next_pair)*((ignore* value_separator) when allow_trailing_comma)?)? ignore*
+                end_object
             ) @exit;
         }%%
 

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -73,6 +73,9 @@ module JSON
       # * *allow_nan*: If set to true, allow NaN, Infinity and -Infinity in
       #   defiance of RFC 7159 to be parsed by the Parser. This option defaults
       #   to false.
+      # * *allow_trailing_comma*: If set to true, allow arrays and objects with a
+      #   trailing comma in defiance of RFC 7159 to be parsed by the Parser.
+      #   This option defaults to false.
       # * *freeze*: If set to true, all parsed objects will be frozen. Parsed
       #   string will be deduplicated if possible.
       # * *symbolize_names*: If set to true, returns symbols for the names
@@ -103,6 +106,7 @@ module JSON
           @max_nesting = 0
         end
         @allow_nan = !!opts[:allow_nan]
+        @allow_trailing_comma = !!opts[:allow_trailing_comma]
         @symbolize_names = !!opts[:symbolize_names]
         @freeze = !!opts[:freeze]
 
@@ -284,7 +288,7 @@ module JSON
               raise ParserError, "expected ',' or ']' in array at '#{peek(20)}'!"
             end
           when scan(ARRAY_CLOSE)
-            if delim
+            if delim && !@allow_trailing_comma
               raise ParserError, "expected next element in array at '#{peek(20)}'!"
             end
             break
@@ -327,7 +331,7 @@ module JSON
               raise ParserError, "expected value in object at '#{peek(20)}'!"
             end
           when scan(OBJECT_CLOSE)
-            if delim
+            if delim && !@allow_trailing_comma
               raise ParserError, "expected next name, value pair in object at '#{peek(20)}'!"
             end
             if @create_additions and klassname = result[@create_id]

--- a/test/json/fixtures/fail4.json
+++ b/test/json/fixtures/fail4.json
@@ -1,1 +1,0 @@
-["extra comma",]

--- a/test/json/fixtures/fail9.json
+++ b/test/json/fixtures/fail9.json
@@ -1,1 +1,0 @@
-{"Extra comma": true,}

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -180,8 +180,94 @@ class JSONParserTest < Test::Unit::TestCase
     assert parse('NaN', :allow_nan => true).nan?
     assert parse('Infinity', :allow_nan => true).infinite?
     assert parse('-Infinity', :allow_nan => true).infinite?
-    assert_raise(JSON::ParserError) { parse('[ 1, ]') }
   end
+
+  def test_parse_arrays_with_allow_trailing_comma
+    assert_equal([], parse('[]', allow_trailing_comma: true))
+    assert_equal([], parse('[]', allow_trailing_comma: false))
+    assert_raise(JSON::ParserError) { parse('[,]', allow_trailing_comma: true) }
+    assert_raise(JSON::ParserError) { parse('[,]', allow_trailing_comma: false) }
+
+    assert_equal([1], parse('[1]', allow_trailing_comma: true))
+    assert_equal([1], parse('[1]', allow_trailing_comma: false))
+    assert_equal([1], parse('[1,]', allow_trailing_comma: true))
+    assert_raise(JSON::ParserError) { parse('[1,]', allow_trailing_comma: false) }
+
+    assert_equal([1, 2, 3], parse('[1,2,3]', allow_trailing_comma: true))
+    assert_equal([1, 2, 3], parse('[1,2,3]', allow_trailing_comma: false))
+    assert_equal([1, 2, 3], parse('[1,2,3,]', allow_trailing_comma: true))
+    assert_raise(JSON::ParserError) { parse('[1,2,3,]', allow_trailing_comma: false) }
+
+    assert_equal([1, 2, 3], parse('[  1  ,  2  ,  3  ]', allow_trailing_comma: true))
+    assert_equal([1, 2, 3], parse('[  1  ,  2  ,  3  ]', allow_trailing_comma: false))
+    assert_equal([1, 2, 3], parse('[  1  ,  2  ,  3  ,  ]', allow_trailing_comma: true))
+    assert_raise(JSON::ParserError) { parse('[  1  ,  2  ,  3  ,  ]', allow_trailing_comma: false) }
+
+    assert_equal({'foo' => [1, 2, 3]}, parse('{ "foo": [1,2,3] }', allow_trailing_comma: true))
+    assert_equal({'foo' => [1, 2, 3]}, parse('{ "foo": [1,2,3] }', allow_trailing_comma: false))
+    assert_equal({'foo' => [1, 2, 3]}, parse('{ "foo": [1,2,3,] }', allow_trailing_comma: true))
+    assert_raise(JSON::ParserError) { parse('{ "foo": [1,2,3,] }', allow_trailing_comma: false) }
+  end
+
+  def test_parse_object_with_allow_trailing_comma
+     assert_equal({}, parse('{}', allow_trailing_comma: true))
+     assert_equal({}, parse('{}', allow_trailing_comma: false))
+     assert_raise(JSON::ParserError) { parse('{,}', allow_trailing_comma: true) }
+     assert_raise(JSON::ParserError) { parse('{,}', allow_trailing_comma: false) }
+
+     assert_equal({'foo'=>'bar'}, parse('{"foo":"bar"}', allow_trailing_comma: true))
+     assert_equal({'foo'=>'bar'}, parse('{"foo":"bar"}', allow_trailing_comma: false))
+     assert_equal({'foo'=>'bar'}, parse('{"foo":"bar",}', allow_trailing_comma: true))
+     assert_raise(JSON::ParserError) { parse('{"foo":"bar",}', allow_trailing_comma: false) }
+
+     assert_equal(
+       {'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'},
+       parse('{"foo":"bar","baz":"qux","quux":"garply"}', allow_trailing_comma: true)
+     )
+     assert_equal(
+       {'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'},
+       parse('{"foo":"bar","baz":"qux","quux":"garply"}', allow_trailing_comma: false)
+     )
+     assert_equal(
+       {'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'},
+       parse('{"foo":"bar","baz":"qux","quux":"garply",}', allow_trailing_comma: true)
+     )
+     assert_raise(JSON::ParserError) {
+       parse('{"foo":"bar","baz":"qux","quux":"garply",}', allow_trailing_comma: false)
+     }
+
+     assert_equal(
+       {'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'},
+       parse('{  "foo":"bar"  ,  "baz":"qux"  ,  "quux":"garply"  }', allow_trailing_comma: true)
+     )
+     assert_equal(
+       {'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'},
+       parse('{  "foo":"bar"  ,  "baz":"qux"  ,  "quux":"garply"  }', allow_trailing_comma: false)
+     )
+     assert_equal(
+       {'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'},
+       parse('{  "foo":"bar"  ,  "baz":"qux"  ,  "quux":"garply"  ,  }', allow_trailing_comma: true)
+     )
+     assert_raise(JSON::ParserError) {
+       parse('{  "foo":"bar"  ,  "baz":"qux"  ,  "quux":"garply"  ,  }', allow_trailing_comma: false)
+     }
+
+     assert_equal(
+       [{'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'}],
+       parse('[{"foo":"bar","baz":"qux","quux":"garply"}]', allow_trailing_comma: true)
+     )
+     assert_equal(
+       [{'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'}],
+       parse('[{"foo":"bar","baz":"qux","quux":"garply"}]', allow_trailing_comma: false)
+     )
+     assert_equal(
+       [{'foo'=>'bar', 'baz'=>'qux', 'quux'=>'garply'}],
+       parse('[{"foo":"bar","baz":"qux","quux":"garply",}]', allow_trailing_comma: true)
+     )
+     assert_raise(JSON::ParserError) {
+       parse('[{"foo":"bar","baz":"qux","quux":"garply",}]', allow_trailing_comma: false)
+     }
+   end
 
   def test_parse_some_strings
     assert_equal([""], parse('[""]'))


### PR DESCRIPTION
Fix: https://github.com/ruby/json/pull/401

Since we already accept comments without even a flag to turn it off, it makes sense to go just one small bit farther and optionally allow trailing comma so we have decent support for what is generally defined as "JSONC" and frequently used for configuration files.