### PR TITLE
Prevent loading both `json/ext` and `json/pure`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'rubygems/package_task'
 rescue LoadError

--- a/json.gemspec
+++ b/json.gemspec
@@ -45,7 +45,11 @@ spec = Gem::Specification.new do |s|
     "LEGAL",
     "README.md",
     "json.gemspec",
-    *Dir["lib/**/*.rb"],
+    *(
+      Dir["lib/**/*.rb"] -
+      # We keep lib/json/pure/*.rb on purpose for TruffleRuby, but not the entry points.
+      Dir["lib/json/pure.rb"] - Dir["lib/json_pure.rb"]
+    ),
   ]
 
   if java_ext

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = ["README.md"]
   s.rdoc_options = ["--title", "JSON implementation for ruby", "--main", "README.md"]
+
   s.files = [
     "CHANGES.md",
     "COPYING",
@@ -23,29 +24,9 @@ Gem::Specification.new do |s|
     "LEGAL",
     "README.md",
     "json_pure.gemspec",
-    "lib/json.rb",
-    "lib/json/add/bigdecimal.rb",
-    "lib/json/add/complex.rb",
-    "lib/json/add/core.rb",
-    "lib/json/add/date.rb",
-    "lib/json/add/date_time.rb",
-    "lib/json/add/exception.rb",
-    "lib/json/add/ostruct.rb",
-    "lib/json/add/range.rb",
-    "lib/json/add/rational.rb",
-    "lib/json/add/regexp.rb",
-    "lib/json/add/set.rb",
-    "lib/json/add/struct.rb",
-    "lib/json/add/symbol.rb",
-    "lib/json/add/time.rb",
-    "lib/json/common.rb",
-    "lib/json/ext.rb",
-    "lib/json/generic_object.rb",
-    "lib/json/pure.rb",
-    "lib/json/pure/generator.rb",
-    "lib/json/pure/parser.rb",
-    "lib/json/version.rb",
+    *(Dir["lib/**/*.rb"] - Dir["lib/json/ext/**/*.rb"]),
   ]
+
   s.homepage = "https://ruby.github.io/json"
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/ruby/json/issues',

--- a/lib/json.rb
+++ b/lib/json.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'json/common'
 
 ##
 # = JavaScript \Object Notation (\JSON)
@@ -582,11 +581,11 @@ require 'json/common'
 #     With custom addition:     #<Foo:0x0000000006473bb8 @bar=0, @baz=1> (Foo)
 #
 module JSON
-  require 'json/version'
+  require_relative 'version'
 
   begin
-    require 'json/ext'
+    require_relative 'ext'
   rescue LoadError
-    require 'json/pure'
+    require_relative 'pure'
   end
 end

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -1,4 +1,5 @@
 #frozen_string_literal: true
+
 require 'json/version'
 
 module JSON

--- a/lib/json/ext.rb
+++ b/lib/json/ext.rb
@@ -1,25 +1,30 @@
 # frozen_string_literal: true
 
-require 'json/common'
+unless defined?(::JSON::JSON_LOADED)
+  module JSON
+    # Prevent json/pure from being loaded at the same time
+    $LOADED_FEATURES << File.expand_path("../pure.rb", __FILE__)
 
-module JSON
-  # This module holds all the modules/classes that implement JSON's
-  # functionality as C extensions.
-  module Ext
+    # We use require_relative to ensure we're not loading files from `json_pure`
+    require_relative 'common'
+
     if RUBY_ENGINE == 'truffleruby'
       require 'json/ext/parser'
-      require 'json/pure'
+      # We use require_relative to make sure we're loading the same version.
+      # Otherwise if the Gemfile include conflicting versions of `json` and `json_pure`
+      # it may break.
+      require_relative 'pure/generator'
       $DEBUG and warn "Using Ext extension for JSON parser and Pure library for JSON generator."
-      JSON.parser = Parser
+      JSON.parser = JSON::Ext::Parser
       JSON.generator = JSON::Pure::Generator
     else
       require 'json/ext/parser'
       require 'json/ext/generator'
       $DEBUG and warn "Using Ext extension for JSON."
-      JSON.parser = Parser
-      JSON.generator = Generator
+      JSON.parser = JSON::Ext::Parser
+      JSON.generator = JSON::Ext::Generator
     end
-  end
 
-  JSON_LOADED = true unless defined?(::JSON::JSON_LOADED)
+    JSON_LOADED = true
+  end
 end

--- a/lib/json/generic_object.rb
+++ b/lib/json/generic_object.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 begin
   require 'ostruct'
 rescue LoadError

--- a/lib/json/pure.rb
+++ b/lib/json/pure.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
-require 'json/common'
 
-module JSON
-  # This module holds all the modules/classes that implement JSON's
-  # functionality in pure ruby.
-  module Pure
-    require 'json/pure/parser'
-    require 'json/pure/generator'
+
+unless defined?(::JSON::JSON_LOADED)
+  module JSON
+    # Prevent json/ext from being loaded at the same time
+    $LOADED_FEATURES << File.expand_path("../ext.rb", __FILE__)
+
+    # We use require_relative to ensure we're not loading files from `json`
+    require_relative 'common'
+    require_relative 'pure/parser'
+    require_relative 'pure/generator'
+
     $DEBUG and warn "Using Pure library for JSON."
-    JSON.parser = Parser
-    JSON.generator = Generator
-  end
+    JSON.parser = JSON::Pure::Parser
+    JSON.generator = JSON::Pure::Generator
 
-  JSON_LOADED = true unless defined?(::JSON::JSON_LOADED)
+    JSON_LOADED = true
+  end
 end

--- a/lib/json_pure.rb
+++ b/lib/json_pure.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'json/pure'


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/650
Ref: https://github.com/ruby/json/issues/646

`json_pure` currently doesn't work well at all because `json/ext` is a default gem, so if you have code requiring `json/pure` and some other code requiring `json`, you end up with both loaded.

If the `json` and `json_pure` versions match, it's not too bad, but if they don't match, you might run into issues with private APIs no longer matching.