### PR TITLE
[2.7.x] Raise JSON::GeneratorError instead of Encoding::UndefinedConversionError

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -954,6 +954,10 @@ static VALUE generate_json_rescue(VALUE d, VALUE exc)
     struct generate_json_data *data = (struct generate_json_data *)d;
     fbuffer_free(data->buffer);
 
+    if (RBASIC_CLASS(exc) == rb_path2class("Encoding::UndefinedConversionError")) {
+        exc = rb_exc_new_str(eGeneratorError, rb_funcall(exc, rb_intern("message"), 0));
+    }
+
     rb_exc_raise(exc);
 
     return Qundef;

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -17,6 +17,7 @@ import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.exceptions.RaiseException;
 
 public final class Generator {
     private Generator() {
@@ -390,14 +391,19 @@ public final class Generator {
                 RuntimeInfo info = session.getInfo();
                 RubyString src;
 
-                if (object.encoding(session.getContext()) != info.utf8.get()) {
-                    src = (RubyString)object.encode(session.getContext(),
-                                                    info.utf8.get());
-                } else {
-                    src = object;
-                }
+                try {
+                    if (object.encoding(session.getContext()) != info.utf8.get()) {
+                        src = (RubyString)object.encode(session.getContext(),
+                                                        info.utf8.get());
+                    } else {
+                        src = object;
+                    }
 
-                session.getStringEncoder().encode(src.getByteList(), buffer);
+                    session.getStringEncoder().encode(src.getByteList(), buffer);
+                } catch (RaiseException re) {
+                  throw Utils.newException(session.getContext(), Utils.M_GENERATOR_ERROR,
+                   re.getMessage());
+                }
             }
         };
 

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -347,7 +347,11 @@ module JSON
         if Regexp.method_defined?(:match?)
           private def fast_serialize_string(string, buf) # :nodoc:
             buf << '"'
-            string = string.encode(::Encoding::UTF_8) unless string.encoding == ::Encoding::UTF_8
+            begin
+              string = string.encode(::Encoding::UTF_8) unless string.encoding == ::Encoding::UTF_8
+            rescue Encoding::UndefinedConversionError => error
+              raise GeneratorError, error.message
+            end
             raise GeneratorError, "source sequence is illegal/malformed utf-8" unless string.valid_encoding?
 
             if /["\\\x0-\x1f]/n.match?(string)
@@ -536,7 +540,11 @@ module JSON
               end
               string = self
             else
-              string = encode(::Encoding::UTF_8)
+              begin
+                string = encode(::Encoding::UTF_8)
+              rescue Encoding::UndefinedConversionError => error
+                raise GeneratorError, error.message
+              end
             end
             if state.ascii_only?
               %("#{JSON.utf8_to_json_ascii(string, state.script_safe)}")

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -470,12 +470,20 @@ EOT
     end
     assert_includes error.message, "source sequence is illegal/malformed utf-8"
 
-    assert_raise(Encoding::UndefinedConversionError) do
+    assert_raise(JSON::GeneratorError) do
+      JSON.dump("\x82\xAC\xEF".b)
+    end
+
+    assert_raise(JSON::GeneratorError) do
       "\x82\xAC\xEF".b.to_json
     end
 
-    assert_raise(Encoding::UndefinedConversionError) do
-      JSON.dump("\x82\xAC\xEF".b)
+    assert_raise(JSON::GeneratorError) do
+      ["\x82\xAC\xEF".b].to_json
+    end
+
+    assert_raise(JSON::GeneratorError) do
+      { foo: "\x82\xAC\xEF".b }.to_json
     end
   end
 


### PR DESCRIPTION
Followup: https://github.com/ruby/json/pull/633

That's what was raised historically. You could argue that this new exception is more precise, but I've encountered some real production code that expected the old behavior and that was broken by this change.