### PR TITLE
JSON.dump: write directly into the provided IO

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -161,7 +161,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   file JRUBY_PARSER_JAR => :compile do
     cd 'java/src' do
       parser_classes = FileList[
-        "json/ext/ByteListTranscoder*.class",
+        "json/ext/ByteList*.class",
         "json/ext/OptionsReader*.class",
         "json/ext/Parser*.class",
         "json/ext/RuntimeInfo*.class",
@@ -179,7 +179,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   file JRUBY_GENERATOR_JAR => :compile do
     cd 'java/src' do
       generator_classes = FileList[
-        "json/ext/ByteListTranscoder*.class",
+        "json/ext/ByteList*.class",
         "json/ext/OptionsReader*.class",
         "json/ext/Generator*.class",
         "json/ext/RuntimeInfo*.class",

--- a/java/src/json/ext/ByteListDirectOutputStream.java
+++ b/java/src/json/ext/ByteListDirectOutputStream.java
@@ -1,0 +1,16 @@
+package json.ext;
+
+import org.jcodings.Encoding;
+import org.jruby.util.ByteList;
+
+import java.io.ByteArrayOutputStream;
+
+public class ByteListDirectOutputStream extends ByteArrayOutputStream {
+    ByteListDirectOutputStream(int size) {
+        super(size);
+    }
+
+    public ByteList toByteListDirect(Encoding encoding) {
+        return new ByteList(buf, 0, count, encoding, false);
+    }
+}

--- a/java/src/json/ext/ByteListTranscoder.java
+++ b/java/src/json/ext/ByteListTranscoder.java
@@ -9,6 +9,9 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 /**
  * A class specialized in transcoding a certain String format into another,
  * using UTF-8 ByteLists as both input and output.
@@ -23,7 +26,7 @@ abstract class ByteListTranscoder {
     /** Position of the next character to read */
     protected int pos;
 
-    private ByteList out;
+    private OutputStream out;
     /**
      * When a character that can be copied straight into the output is found,
      * its index is stored on this variable, and copying is delayed until
@@ -37,11 +40,11 @@ abstract class ByteListTranscoder {
         this.context = context;
     }
 
-    protected void init(ByteList src, ByteList out) {
+    protected void init(ByteList src, OutputStream out) {
         this.init(src, 0, src.length(), out);
     }
 
-    protected void init(ByteList src, int start, int end, ByteList out) {
+    protected void init(ByteList src, int start, int end, OutputStream out) {
         this.src = src;
         this.pos = start;
         this.charStart = start;
@@ -142,19 +145,19 @@ abstract class ByteListTranscoder {
      *               recently read character, or {@link #charStart} to quote
      *               until the character before it.
      */
-    protected void quoteStop(int endPos) {
+    protected void quoteStop(int endPos) throws IOException {
         if (quoteStart != -1) {
-            out.append(src, quoteStart, endPos - quoteStart);
+            out.write(src.bytes(), quoteStart, endPos - quoteStart);
             quoteStart = -1;
         }
     }
 
-    protected void append(int b) {
-        out.append(b);
+    protected void append(int b) throws IOException {
+        out.write(b);
     }
 
-    protected void append(byte[] origin, int start, int length) {
-        out.append(origin, start, length);
+    protected void append(byte[] origin, int start, int length) throws IOException {
+        out.write(origin, start, length);
     }
 
 

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -59,11 +59,16 @@ public final class Generator {
      */
     public static <T extends IRubyObject> IRubyObject
             generateJson(ThreadContext context, T object,
-                         GeneratorState config) {
+                         GeneratorState config, IRubyObject io) {
         Session session = new Session(context, config);
         Handler<? super T> handler = getHandlerFor(context.runtime, object);
 
-        return handler.generateNew(session, object);
+        if (io.isNil()) {
+            return handler.generateNew(session, object);
+        }
+
+        handler.generateToBuffer(session, object, new IOOutputStream(io));
+        return io;
     }
 
     /**

--- a/java/src/json/ext/GeneratorService.java
+++ b/java/src/json/ext/GeneratorService.java
@@ -37,6 +37,8 @@ public class GeneratorService implements BasicLibraryService {
             generatorModule.defineModuleUnder("GeneratorMethods");
         GeneratorMethods.populate(info, generatorMethods);
 
+        runtime.getLoadService().require("json/ext/generator/state");
+
         return true;
     }
 }

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -230,15 +230,21 @@ public class GeneratorState extends RubyObject {
      */
     @JRubyMethod
     public IRubyObject generate(ThreadContext context, IRubyObject obj) {
-        RubyString result = Generator.generateJson(context, obj, this);
+        IRubyObject result = Generator.generateJson(context, obj, this);
         RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
-        if (result.getEncoding() != UTF8Encoding.INSTANCE) {
-            if (result.isFrozen()) {
-                result = result.strDup(context.getRuntime());
-            }
-            result.force_encoding(context, info.utf8.get());
+        if (!(result instanceof RubyString)) {
+            return result;
         }
-        return result;
+
+        RubyString resultString = result.convertToString();
+        if (resultString.getEncoding() != UTF8Encoding.INSTANCE) {
+            if (resultString.isFrozen()) {
+                resultString = resultString.strDup(context.getRuntime());
+            }
+            resultString.force_encoding(context, info.utf8.get());
+        }
+
+        return resultString;
     }
 
     private static boolean matchClosingBrace(ByteList bl, int pos, int len,

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -139,8 +139,8 @@ public class GeneratorState extends RubyObject {
     }
 
     @JRubyMethod(meta=true)
-    public static IRubyObject generate(ThreadContext context, IRubyObject klass, IRubyObject obj, IRubyObject opts) {
-        return fromState(context, opts).generate(context, obj);
+    public static IRubyObject generate(ThreadContext context, IRubyObject klass, IRubyObject obj, IRubyObject opts, IRubyObject io) {
+        return fromState(context, opts)._generate(context, obj, io);
     }
 
     static GeneratorState fromState(ThreadContext context, IRubyObject opts) {
@@ -196,7 +196,7 @@ public class GeneratorState extends RubyObject {
      */
     @JRubyMethod(optional=1, visibility=Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
-        configure(context, args.length > 0 ? args[0] : null);
+        _configure(context, args.length > 0 ? args[0] : null);
         return this;
     }
 
@@ -228,9 +228,9 @@ public class GeneratorState extends RubyObject {
      * the result. If no valid JSON document can be created this method raises
      * a GeneratorError exception.
      */
-    @JRubyMethod
-    public IRubyObject generate(ThreadContext context, IRubyObject obj) {
-        IRubyObject result = Generator.generateJson(context, obj, this);
+    @JRubyMethod(visibility = Visibility.PRIVATE)
+    public IRubyObject _generate(ThreadContext context, IRubyObject obj, IRubyObject io) {
+        IRubyObject result = Generator.generateJson(context, obj, this, io);
         RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
         if (!(result instanceof RubyString)) {
             return result;
@@ -411,7 +411,7 @@ public class GeneratorState extends RubyObject {
         return strict;
     }
 
-    @JRubyMethod(name="strict")
+    @JRubyMethod(name={"strict","strict?"})
     public RubyBoolean strict_get(ThreadContext context) {
         return context.getRuntime().newBoolean(strict);
     }
@@ -484,8 +484,8 @@ public class GeneratorState extends RubyObject {
      * @param vOpts The options hash
      * @return The receiver
      */
-  @JRubyMethod(alias = "merge")
-    public IRubyObject configure(ThreadContext context, IRubyObject vOpts) {
+  @JRubyMethod(visibility=Visibility.PRIVATE)
+    public IRubyObject _configure(ThreadContext context, IRubyObject vOpts) {
         OptionsReader opts = new OptionsReader(context, vOpts);
 
         ByteList indent = opts.getString("indent");

--- a/java/src/json/ext/StringDecoder.java
+++ b/java/src/json/ext/StringDecoder.java
@@ -9,6 +9,8 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
+import java.io.IOException;
+
 /**
  * A decoder that reads a JSON-encoded string from the given sources and
  * returns its decoded form on a new ByteList. Escaped Unicode characters
@@ -29,17 +31,20 @@ final class StringDecoder extends ByteListTranscoder {
     }
 
     ByteList decode(ByteList src, int start, int end) {
-        ByteList out = new ByteList(end - start);
-        out.setEncoding(src.getEncoding());
-        init(src, start, end, out);
-        while (hasNext()) {
-            handleChar(readUtf8Char());
+        try {
+            ByteListDirectOutputStream out = new ByteListDirectOutputStream(end - start);
+            init(src, start, end, out);
+            while (hasNext()) {
+                handleChar(readUtf8Char());
+            }
+            quoteStop(pos);
+            return out.toByteListDirect(src.getEncoding());
+        } catch (IOException e) {
+            throw context.runtime.newIOErrorFromException(e);
         }
-        quoteStop(pos);
-        return out;
     }
 
-    private void handleChar(int c) {
+    private void handleChar(int c) throws IOException {
         if (c == '\\') {
             quoteStop(charStart);
             handleEscapeSequence();
@@ -48,7 +53,7 @@ final class StringDecoder extends ByteListTranscoder {
         }
     }
 
-    private void handleEscapeSequence() {
+    private void handleEscapeSequence() throws IOException {
         ensureMin(1);
         switch (readUtf8Char()) {
         case 'b':
@@ -83,7 +88,7 @@ final class StringDecoder extends ByteListTranscoder {
         }
     }
 
-    private void handleLowSurrogate(char highSurrogate) {
+    private void handleLowSurrogate(char highSurrogate) throws IOException {
         surrogatePairStart = charStart;
         ensureMin(1);
         int lowSurrogate = readUtf8Char();
@@ -103,7 +108,7 @@ final class StringDecoder extends ByteListTranscoder {
         }
     }
 
-    private void writeUtf8Char(int codePoint) {
+    private void writeUtf8Char(int codePoint) throws IOException {
         if (codePoint < 0x80) {
             append(codePoint);
         } else if (codePoint < 0x800) {

--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -9,6 +9,9 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 /**
  * An encoder that reads from the given source and outputs its representation
  * to another ByteList. The source string is fully checked for UTF-8 validity,
@@ -43,7 +46,7 @@ final class StringEncoder extends ByteListTranscoder {
         this.scriptSafe = scriptSafe;
     }
 
-    void encode(ByteList src, ByteList out) {
+    void encode(ByteList src, OutputStream out) throws IOException {
         init(src, out);
         append('"');
         while (hasNext()) {
@@ -53,7 +56,7 @@ final class StringEncoder extends ByteListTranscoder {
         append('"');
     }
 
-    private void handleChar(int c) {
+    private void handleChar(int c) throws IOException {
         switch (c) {
         case '"':
         case '\\':
@@ -97,13 +100,13 @@ final class StringEncoder extends ByteListTranscoder {
         }
     }
 
-    private void escapeChar(char c) {
+    private void escapeChar(char c) throws IOException {
         quoteStop(charStart);
         aux[ESCAPE_CHAR_OFFSET + 1] = (byte)c;
         append(aux, ESCAPE_CHAR_OFFSET, 2);
     }
 
-    private void escapeUtf8Char(int codePoint) {
+    private void escapeUtf8Char(int codePoint) throws IOException {
         int numChars = Character.toChars(codePoint, utf16, 0);
         escapeCodeUnit(utf16[0], ESCAPE_UNI1_OFFSET + 2);
         if (numChars > 1) escapeCodeUnit(utf16[1], ESCAPE_UNI2_OFFSET + 2);

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -286,7 +286,7 @@ module JSON
     if State === opts
       opts.generate(obj)
     else
-      State.generate(obj, opts)
+      State.generate(obj, opts, nil)
     end
   end
 
@@ -801,17 +801,14 @@ module JSON
     opts = opts.merge(:max_nesting => limit) if limit
     opts = merge_dump_options(opts, **kwargs) if kwargs
 
-    result = begin
-      generate(obj, opts)
+    begin
+      if State === opts
+        opts.generate(obj, anIO)
+      else
+        State.generate(obj, opts, anIO)
+      end
     rescue JSON::NestingError
       raise ArgumentError, "exceed depth limit"
-    end
-
-    if anIO.nil?
-      result
-    else
-      anIO.write result
-      anIO
     end
   end
 

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -47,6 +47,17 @@ module JSON
 
         alias_method :merge, :configure
 
+        # call-seq:
+        #   generate(obj) -> String
+        #   generate(obj, anIO) -> anIO
+        #
+        # Generates a valid JSON document from object +obj+ and returns the
+        # result. If no valid JSON document can be created this method raises a
+        # GeneratorError exception.
+        def generate(obj, io = nil)
+          _generate(obj, io)
+        end
+
         # call-seq: to_h
         #
         # Returns the configuration instance variables as a hash, that can be

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -96,8 +96,14 @@ module JSON
       # This class is used to create State instances, that are use to hold data
       # while generating a JSON text from a Ruby data structure.
       class State
-        def self.generate(obj, opts = nil)
-          new(opts).generate(obj)
+        def self.generate(obj, opts = nil, io = nil)
+          string = new(opts).generate(obj)
+          if io
+            io.write(string)
+            io
+          else
+            string
+          end
         end
 
         # Creates a State object from _opts_, which ought to be Hash to create

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -162,6 +162,17 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     assert_equal too_deep, dump(obj, strict: false)
   end
 
+  def test_dump_in_io
+    io = StringIO.new
+    assert_same io, JSON.dump([1], io)
+    assert_equal "[1]", io.string
+
+    big_object = ["a" * 10, "b" * 40, { foo: 1.23 }] * 5000
+    io.rewind
+    assert_same io, JSON.dump(big_object, io)
+    assert_equal JSON.dump(big_object), io.string
+  end
+
   def test_dump_should_modify_defaults
     max_nesting = JSON.dump_default_options[:max_nesting]
     dump([], StringIO.new, 10)


### PR DESCRIPTION
Ref: https://github.com/ruby/json/issues/524

Fix: https://github.com/ruby/json/pull/538
Fix: https://github.com/ruby/json/issues/524

Rather than to buffer everything in memory.

Unfortunately Ruby doesn't provide an API to write into and IO without first allocating a string, which is a bit wasteful.

FYI: @headius 