### PR TITLE
CI: ci.yml - update to actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         - { os: windows-latest, ruby: jruby-head }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby-pkgs@v1
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby-pkgs@v1


### PR DESCRIPTION
Fixes Actions warning like:
```text
macos-14 3.2 The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3.
For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default
Show more
```