### PR TITLE
Mark parser.c and Parser.java as generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+ext/json/ext/parser/parser.c linguist-generated=true
+java/src/json/ext/Parser.java linguist-generated=true


### PR DESCRIPTION
This way they're hidden in diffs.

It would be good to enforce on CI that the generated files match the source change, however ragel's output isn't consistent across versions and system, so we'll have to rely on changes being noticed by further contributions.