### PR TITLE
JSON.load_file: explictly load the file as UTF-8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* `JSON.load_file` explictly read the file as UTF-8.
+
 ### 2024-11-06 (2.8.1)
 
 * Fix the java packages to include the extension.

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -1,4 +1,5 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
+
 require 'json/version'
 
 module JSON
@@ -230,8 +231,8 @@ module JSON
   #   parse(File.read(path), opts)
   #
   # See method #parse.
-  def load_file(filespec, opts = {})
-    parse(File.read(filespec), opts)
+  def load_file(filespec, opts = nil)
+    parse(File.read(filespec, encoding: Encoding::UTF_8), opts)
   end
 
   # :call-seq:
@@ -242,7 +243,7 @@ module JSON
   #
   # See method #parse!
   def load_file!(filespec, opts = {})
-    parse!(File.read(filespec), opts)
+    parse!(File.read(filespec, encoding: Encoding::UTF_8), opts)
   end
 
   # :call-seq:

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'test_helper'
 require 'stringio'
 require 'tempfile'
@@ -189,7 +190,29 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     test_load_file_with_option_shared(:load_file!)
   end
 
+  def test_load_file_with_bad_default_external_encoding
+    data = { "key" => "€" }
+    temp_file_containing(JSON.dump(data)) do |path|
+      loaded_data = with_external_encoding(Encoding::US_ASCII) do
+        JSON.load_file(path)
+      end
+      assert_equal data, loaded_data
+    end
+  end
+
   private
+
+  def with_external_encoding(encoding)
+    verbose = $VERBOSE
+    $VERBOSE = nil
+    previous_encoding = Encoding.default_external
+    Encoding.default_external = encoding
+    yield
+  ensure
+    verbose = $VERBOSE
+    Encoding.default_external = previous_encoding
+    $VERBOSE = verbose
+  end
 
   def test_load_shared(method_name)
     temp_file_containing(@json) do |filespec|


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/697

This way even if `Encoding.default_external` is set to a weird value the document will be parsed just fine.