### PR TITLE
Fix $VERBOSE restore

### DIFF
--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -209,7 +209,6 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     Encoding.default_external = encoding
     yield
   ensure
-    verbose = $VERBOSE
     Encoding.default_external = previous_encoding
     $VERBOSE = verbose
   end


### PR DESCRIPTION
Found this in ruby ci random failure
```
  1) Failure:
TestIRB::ShowDocTest#test_show_doc_without_rdoc [/tmp/ruby/src/trunk-random1/test/irb/test_command.rb:775]:
Expected "" to include "Can't display document because `rdoc` is not installed.\n".
```
The expected warning is suppressed because `$VERBOSE` is changed to nil