### PR TITLE
Fix redundant to_str call in JSON.[] method

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -26,7 +26,7 @@ module JSON
       elsif object.respond_to?(:to_str)
         str = object.to_str
         if str.is_a?(String)
-          return JSON.parse(object.to_str, opts)
+          return JSON.parse(str, opts)
         end
       end
 


### PR DESCRIPTION
ref: #499 

Fixed an inefficiency in the `JSON.[]` method where `to_str` was being called twice unnecessarily. 

## Changes
- Modified the `JSON.[]` method to reuse the converted string instead of calling `to_str` again
- No functional changes, only performance optimization