### PR TITLE
JSON::GeneratorError expose invalid object

### DIFF
--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -142,6 +142,6 @@ final class StringEncoder extends ByteListTranscoder {
 
     @Override
     protected RaiseException invalidUtf8(ThreadContext context) {
-         return Utils.newException(context, Utils.M_GENERATOR_ERROR, "source sequence is illegal/malformed utf-8");
+        return Utils.newException(context, Utils.M_GENERATOR_ERROR, "source sequence is illegal/malformed utf-8");
     }
 }

--- a/java/src/json/ext/Utils.java
+++ b/java/src/json/ext/Utils.java
@@ -63,6 +63,18 @@ final class Utils {
         return excptn.toThrowable();
     }
 
+    static RubyException buildGeneratorError(ThreadContext context, IRubyObject invalidObject, RubyString message) {
+        RuntimeInfo info = RuntimeInfo.forRuntime(context.runtime);
+        RubyClass klazz = info.jsonModule.get().getClass(M_GENERATOR_ERROR);
+        RubyException excptn = (RubyException)klazz.newInstance(context, message, Block.NULL_BLOCK);
+        excptn.setInstanceVariable("@invalid_object", invalidObject);
+        return excptn;
+    }
+
+    static RubyException buildGeneratorError(ThreadContext context, IRubyObject invalidObject, String message) {
+        return buildGeneratorError(context, invalidObject, context.runtime.newString(message));
+    }
+
     static byte[] repeat(ByteList a, int n) {
         return repeat(a.unsafeBytes(), a.begin(), a.length(), n);
     }

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -143,7 +143,23 @@ module JSON
   # :startdoc:
 
   # This exception is raised if a generator or unparser error occurs.
-  class GeneratorError < JSONError; end
+  class GeneratorError < JSONError
+    attr_reader :invalid_object
+
+    def initialize(message, invalid_object = nil)
+      super(message)
+      @invalid_object = invalid_object
+    end
+
+    def detailed_message(...)
+      if @invalid_object.nil?
+        super
+      else
+        "#{super}\nInvalid object: #{@invalid_object.inspect}"
+      end
+    end
+  end
+
   # For backwards compatibility
   UnparserError = GeneratorError # :nodoc:
 


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/710

Makes it easier to debug why a given tree of objects can't be dumped as JSON.