### PR TITLE
Prevent a warning of "a candidate for gnu_printf format attribute"

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -84,6 +84,9 @@ static void raise_generator_error_str(VALUE invalid_object, VALUE str)
 #ifdef RBIMPL_ATTR_NORETURN
 RBIMPL_ATTR_NORETURN()
 #endif
+#ifdef RBIMPL_ATTR_FORMAT
+RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
+#endif
 static void raise_generator_error(VALUE invalid_object, const char *fmt, ...)
 {
     va_list args;


### PR DESCRIPTION
GCC 13 prints the following warning.

https://rubyci.s3.amazonaws.com/ubuntu/ruby-master/log/20241127T001003Z.log.html.gz
```
compiling generator.c
generator.c: In function ‘raise_generator_error’:
generator.c:91:5: warning: function ‘raise_generator_error’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
   91 |     VALUE str = rb_vsprintf(fmt, args);
      |     ^~~~~
```

This change prevents the warning by specifying the format attribute.