### PR TITLE
Fix generate(script_safe: true) to not confuse unrelated characters

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -155,7 +155,7 @@ static void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str, const char esca
                 }
                 case 3: {
                     unsigned char b2 = ptr[pos + 1];
-                    if (RB_UNLIKELY(out_script_safe && b2 == 0x80)) {
+                    if (RB_UNLIKELY(out_script_safe && ch == 0xE2 && b2 == 0x80)) {
                         unsigned char b3 = ptr[pos + 2];
                         if (b3 == 0xA8) {
                             FLUSH_POS(3);

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -455,6 +455,10 @@ class JSONGeneratorTest < Test::Unit::TestCase
     data = ["'"]
     json = '["\\\'"]'
     assert_equal '["\'"]', generate(data)
+    #
+    data = ["倩", "瀨"]
+    json = '["倩","瀨"]'
+    assert_equal json, generate(data, script_safe: true)
   end
 
   def test_string_subclass


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/715

The first byte check was missing.