### PR TITLE
Introduce JSON::Coder

### DIFF
--- a/benchmark/encoder.rb
+++ b/benchmark/encoder.rb
@@ -17,8 +17,10 @@ end
 
 def implementations(ruby_obj)
   state = JSON::State.new(JSON.dump_default_options)
+  coder = JSON::Coder.new
   {
     json: ["json", proc { JSON.generate(ruby_obj) }],
+    json_coder: ["json_coder", proc { coder.dump(ruby_obj) }],
     oj: ["oj", proc { Oj.dump(ruby_obj) }],
   }
 end

--- a/benchmark/parser.rb
+++ b/benchmark/parser.rb
@@ -15,9 +15,11 @@ end
 
 def benchmark_parsing(name, json_output)
   puts "== Parsing #{name} (#{json_output.size} bytes)"
+  coder = JSON::Coder.new
 
   Benchmark.ips do |x|
     x.report("json")      { JSON.parse(json_output) } if RUN[:json]
+    x.report("json_coder") { coder.load(json_output) } if RUN[:json_coder]
     x.report("oj")        { Oj.load(json_output) } if RUN[:oj]
     x.report("Oj::Parser") { Oj::Parser.new(:usual).parse(json_output) } if RUN[:oj]
     x.report("rapidjson") { RapidJSON.parse(json_output) } if RUN[:rapidjson]

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -510,6 +510,14 @@ public final class Generator {
             RubyString generateNew(ThreadContext context, Session session, IRubyObject object) {
                 GeneratorState state = session.getState(context);
                 if (state.strict()) {
+                    if (state.getAsJSON() != null ) {
+                        IRubyObject value = state.getAsJSON().call(context, object);
+                        Handler handler = getHandlerFor(context.runtime, value);
+                        if (handler == GENERIC_HANDLER) {
+                            throw Utils.buildGeneratorError(context, object, value + " returned by as_json not allowed in JSON").toThrowable();
+                        }
+                        return handler.generateNew(context, session, value);
+                    }
                     throw Utils.buildGeneratorError(context, object, object + " not allowed in JSON").toThrowable();
                 } else if (object.respondsTo("to_json")) {
                     IRubyObject result = object.callMethod(context, "to_json", state);

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -5,6 +5,8 @@
  */
 package json.ext;
 
+import json.ext.RuntimeInfo;
+
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
@@ -115,6 +117,11 @@ public final class Generator {
             case HASH   :
                 if (Helpers.metaclass(object) != runtime.getHash()) break;
                 return (Handler<T>) HASH_HANDLER;
+            case STRUCT :
+                RuntimeInfo info = RuntimeInfo.forRuntime(runtime);
+                RubyClass fragmentClass = info.jsonModule.get().getClass("Fragment");
+                if (Helpers.metaclass(object) != fragmentClass) break;
+                return (Handler<T>) FRAGMENT_HANDLER;
         }
         return GENERIC_HANDLER;
     }
@@ -480,6 +487,28 @@ public final class Generator {
             new KeywordHandler<>("false");
     static final Handler<IRubyObject> NIL_HANDLER =
             new KeywordHandler<>("null");
+
+    /**
+     * The default handler (<code>Object#to_json</code>): coerces the object
+     * to string using <code>#to_s</code>, and serializes that string.
+     */
+    static final Handler<IRubyObject> FRAGMENT_HANDLER =
+        new Handler<IRubyObject>() {
+            @Override
+            RubyString generateNew(ThreadContext context, Session session, IRubyObject object) {
+                GeneratorState state = session.getState(context);
+                IRubyObject result = object.callMethod(context, "to_json", state);
+                if (result instanceof RubyString) return (RubyString)result;
+                throw context.runtime.newTypeError("to_json must return a String");
+            }
+
+            @Override
+            void generate(ThreadContext context, Session session, IRubyObject object, OutputStream buffer) throws IOException {
+                RubyString result = generateNew(context, session, object);
+                ByteList bytes = result.getByteList();
+                buffer.write(bytes.unsafeBytes(), bytes.begin(), bytes.length());
+            }
+        };
 
     /**
      * The default handler (<code>Object#to_json</code>): coerces the object

--- a/java/src/json/ext/OptionsReader.java
+++ b/java/src/json/ext/OptionsReader.java
@@ -10,10 +10,12 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyNumeric;
+import org.jruby.RubyProc;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.TypeConverter;
 
 final class OptionsReader {
     private final ThreadContext context;
@@ -109,5 +111,11 @@ final class OptionsReader {
         IRubyObject value = get(key);
         if (value == null || value.isNil()) return new RubyHash(runtime);
         return (RubyHash) value;
+    }
+
+    RubyProc getProc(String key) {
+        IRubyObject value = get(key);
+        if (value == null) return null;
+        return (RubyProc)TypeConverter.convertToType(value, runtime.getProc(), "to_proc");
     }
 }

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -174,7 +174,18 @@ module JSON
   # This allows to easily assemble multiple JSON fragments that have
   # been peristed somewhere without having to parse them nor resorting
   # to string interpolation.
+  #
+  # Note: no validation is performed on the provided string. it is the
+  # responsability of the caller to ensure the string contains valid JSON.
   Fragment = Struct.new(:json) do
+    def initialize(json)
+      unless string = String.try_convert(json)
+        raise TypeError, " no implicit conversion of #{json.class} into String"
+      end
+
+      super(string)
+    end
+
     def to_json(state = nil, *)
       json
     end
@@ -850,6 +861,82 @@ module JSON
 
   class << self
     private :merge_dump_options
+  end
+
+  # JSON::Coder holds a parser and generator configuration.
+  #
+  #   module MyApp
+  #     JSONC_CODER = JSON::Coder.new(
+  #       allow_trailing_comma: true
+  #     )
+  #   end
+  #
+  #   MyApp::JSONC_CODER.load(document)
+  #
+  class Coder
+    # :call-seq:
+    #   JSON.new(options = nil, &block)
+    #
+    # Argument +options+, if given, contains a \Hash of options for both parsing and generating.
+    # See {Parsing Options}[#module-JSON-label-Parsing+Options], and {Generating Options}[#module-JSON-label-Generating+Options].
+    #
+    # For generation, the <tt>strict: true</tt> option is always set. When a Ruby object with no native \JSON counterpart is
+    # encoutered, the block provided to the initialize method is invoked, and must return a Ruby object that has a native
+    # \JSON counterpart:
+    #
+    #  module MyApp
+    #    API_JSON_CODER = JSON::Coder.new do |object|
+    #      case object
+    #      when Time
+    #        object.iso8601(3)
+    #      else
+    #        object # Unknown type, will raise
+    #      end
+    #    end
+    #  end
+    #
+    #  puts MyApp::API_JSON_CODER.dump(Time.now.utc) # => "2025-01-21T08:41:44.286Z"
+    #
+    def initialize(options = nil, &as_json)
+      if options.nil?
+        options = { strict: true }
+      else
+        options = options.dup
+        options[:strict] = true
+      end
+      options[:as_json] = as_json if as_json
+      options[:create_additions] = false unless options.key?(:create_additions)
+
+      @state = State.new(options).freeze
+      @parser_config = Ext::Parser::Config.new(options)
+    end
+
+    # call-seq:
+    #   dump(object) -> String
+    #   dump(object, io) -> io
+    #
+    # Serialize the given object into a \JSON document.
+    def dump(object, io = nil)
+      @state.generate_new(object, io)
+    end
+    alias_method :generate, :dump
+
+    # call-seq:
+    #   load(string) -> Object
+    #
+    # Parse the given \JSON document and return an equivalent Ruby object.
+    def load(source)
+      @parser_config.parse(source)
+    end
+    alias_method :parse, :load
+
+    # call-seq:
+    #   load(path) -> Object
+    #
+    # Parse the given \JSON document and return an equivalent Ruby object.
+    def load_file(path)
+      load(File.read(path, encoding: Encoding::UTF_8))
+    end
   end
 end
 

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -58,6 +58,7 @@ module JSON
             space_before: space_before,
             object_nl: object_nl,
             array_nl: array_nl,
+            as_json: as_json,
             allow_nan: allow_nan?,
             ascii_only: ascii_only?,
             max_nesting: max_nesting,

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -416,10 +416,10 @@ module JSON
             state = State.from_state(state) if state
             if state&.strict?
               value = self
-              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value)
+              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
                 if state.as_json
                   value = state.as_json.call(value)
-                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value
+                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
                   value.to_json(state)
@@ -476,10 +476,10 @@ module JSON
               end
 
               result = +"#{result}#{key_json}#{state.space_before}:#{state.space}"
-              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value)
+              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
                 if state.as_json
                   value = state.as_json.call(value)
-                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value
+                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
                   result << value.to_json(state)
@@ -537,10 +537,10 @@ module JSON
             each { |value|
               result << delim unless first
               result << state.indent * depth if indent
-              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value)
+              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
                 if state.as_json
                   value = state.as_json.call(value)
-                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value
+                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
                   result << value.to_json(state)

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -105,16 +105,17 @@ module JSON
         # an unconfigured instance. If _opts_ is a State object, it is just
         # returned.
         def self.from_state(opts)
-          case
-          when self === opts
-            opts
-          when opts.respond_to?(:to_hash)
-            new(opts.to_hash)
-          when opts.respond_to?(:to_h)
-            new(opts.to_h)
-          else
-            SAFE_STATE_PROTOTYPE.dup
+          if opts
+            case
+            when self === opts
+              return opts
+            when opts.respond_to?(:to_hash)
+              return new(opts.to_hash)
+            when opts.respond_to?(:to_h)
+              return new(opts.to_h)
+            end
           end
+          SAFE_STATE_PROTOTYPE.dup
         end
 
         # Instantiates a new State object, configured by _opts_.
@@ -142,6 +143,7 @@ module JSON
           @array_nl              = ''
           @allow_nan             = false
           @ascii_only            = false
+          @as_json               = false
           @depth                 = 0
           @buffer_initial_length = 1024
           @script_safe           = false
@@ -166,6 +168,9 @@ module JSON
 
         # This string is put at the end of a line that holds a JSON array.
         attr_accessor :array_nl
+
+        # This proc converts unsupported types into native JSON types.
+        attr_accessor :as_json
 
         # This integer returns the maximum level of data structure nesting in
         # the generated JSON, max_nesting = 0 if no maximum is checked.
@@ -251,6 +256,7 @@ module JSON
           @object_nl             = opts[:object_nl]     || '' if opts.key?(:object_nl)
           @array_nl              = opts[:array_nl]      || '' if opts.key?(:array_nl)
           @allow_nan             = !!opts[:allow_nan]         if opts.key?(:allow_nan)
+          @as_json               = opts[:as_json].to_proc     if opts.key?(:as_json)
           @ascii_only            = opts[:ascii_only]          if opts.key?(:ascii_only)
           @depth                 = opts[:depth] || 0
           @buffer_initial_length ||= opts[:buffer_initial_length]
@@ -310,6 +316,10 @@ module JSON
           else
             result
           end
+        end
+
+        def generate_new(obj, anIO = nil) # :nodoc:
+          dup.generate(obj, anIO)
         end
 
         # Handles @allow_nan, @buffer_initial_length, other ivars must be the default value (see above)
@@ -403,8 +413,20 @@ module JSON
           # it to a JSON string, and returns the result. This is a fallback, if no
           # special method #to_json was defined for some object.
           def to_json(state = nil, *)
-            if state && State.from_state(state).strict?
-              raise GeneratorError.new("#{self.class} not allowed in JSON", self)
+            state = State.from_state(state) if state
+            if state&.strict?
+              value = self
+              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value)
+                if state.as_json
+                  value = state.as_json.call(value)
+                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value
+                    raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
+                  end
+                  value.to_json(state)
+                else
+                  raise GeneratorError.new("#{value.class} not allowed in JSON", value)
+                end
+              end
             else
               to_s.to_json
             end
@@ -455,7 +477,15 @@ module JSON
 
               result = +"#{result}#{key_json}#{state.space_before}:#{state.space}"
               if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value)
-                raise GeneratorError.new("#{value.class} not allowed in JSON", value)
+                if state.as_json
+                  value = state.as_json.call(value)
+                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value
+                    raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
+                  end
+                  result << value.to_json(state)
+                else
+                  raise GeneratorError.new("#{value.class} not allowed in JSON", value)
+                end
               elsif value.respond_to?(:to_json)
                 result << value.to_json(state)
               else
@@ -508,7 +538,15 @@ module JSON
               result << delim unless first
               result << state.indent * depth if indent
               if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value)
-                raise GeneratorError.new("#{value.class} not allowed in JSON", value)
+                if state.as_json
+                  value = state.as_json.call(value)
+                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value
+                    raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
+                  end
+                  result << value.to_json(state)
+                else
+                  raise GeneratorError.new("#{value.class} not allowed in JSON", value)
+                end
               elsif value.respond_to?(:to_json)
                 result << value.to_json(state)
               else

--- a/test/json/json_coder_test.rb
+++ b/test/json/json_coder_test.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class JSONCoderTest < Test::Unit::TestCase
+  def test_json_coder_with_proc
+    coder = JSON::Coder.new do |object|
+      "[Object object]"
+    end
+    assert_equal %(["[Object object]"]), coder.dump([Object.new])
+  end
+
+  def test_json_coder_with_proc_with_unsupported_value
+    coder = JSON::Coder.new do |object|
+      Object.new
+    end
+    assert_raise(JSON::GeneratorError) { coder.dump([Object.new]) }
+  end
+
+  def test_json_coder_options
+    coder = JSON::Coder.new(array_nl: "\n") do |object|
+      42
+    end
+
+    assert_equal "[\n42\n]", coder.dump([Object.new])
+  end
+
+  def test_json_coder_load
+    coder = JSON::Coder.new
+    assert_equal [1,2,3], coder.load("[1,2,3]")
+  end
+
+  def test_json_coder_load_options
+    coder = JSON::Coder.new(symbolize_names: true)
+    assert_equal({a: 1}, coder.load('{"a":1}'))
+  end
+end

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -200,6 +200,7 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_equal({
       :allow_nan             => false,
       :array_nl              => "\n",
+      :as_json               => false,
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :depth                 => 0,
@@ -218,6 +219,7 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_equal({
       :allow_nan             => false,
       :array_nl              => "",
+      :as_json               => false,
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :depth                 => 0,
@@ -236,6 +238,7 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_equal({
       :allow_nan             => false,
       :array_nl              => "",
+      :as_json               => false,
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :depth                 => 0,
@@ -665,5 +668,10 @@ class JSONGeneratorTest < Test::Unit::TestCase
   def test_fragment
     fragment = JSON::Fragment.new(" 42")
     assert_equal '{"number": 42}', JSON.generate({ number: fragment })
+  end
+
+  def test_json_generate_as_json_convert_to_proc
+    object = Object.new
+    assert_equal object.object_id.to_json, JSON.generate(object, strict: true, as_json: :object_id)
   end
 end

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -668,6 +668,7 @@ class JSONGeneratorTest < Test::Unit::TestCase
   def test_fragment
     fragment = JSON::Fragment.new(" 42")
     assert_equal '{"number": 42}', JSON.generate({ number: fragment })
+    assert_equal '{"number": 42}', JSON.generate({ number: fragment }, strict: true)
   end
 
   def test_json_generate_as_json_convert_to_proc


### PR DESCRIPTION
Since `#to_json` methods are global, it can sometimes be problematic if you need a given type to be
serialized in different ways in different locations.

Instead it is recommended to use the newer `JSON::Coder` API:

```ruby
module MyApp
  API_JSON_CODER = JSON::Coder.new do |object|
    case object
    when Time
      object.iso8601(3)
    else
      object
    end
  end
end

puts MyApp::API_JSON_CODER.dump(Time.now.utc) # => "2025-01-21T08:41:44.286Z"
```

The provided block is called for all objects that don't have a native JSON equivalent, and
must return a Ruby object that has a native JSON equivalent.
