### PR TITLE
Add support for Solaris 10 which lacks strnlen()

### DIFF
--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -5,6 +5,7 @@ have_func("rb_enc_interned_str", "ruby.h") # RUBY_VERSION >= 3.0
 have_func("rb_hash_new_capa", "ruby.h") # RUBY_VERSION >= 3.2
 have_func("rb_hash_bulk_insert", "ruby.h") # Missing on TruffleRuby
 have_func("rb_category_warn", "ruby.h") # Missing on TruffleRuby
+have_func("strnlen", "string.h") # Missing on Solaris 10
 
 append_cflags("-std=c99")
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -417,6 +417,14 @@ static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *resu
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 
 
+#ifndef HAVE_STRNLEN
+static size_t strnlen(const char *s, size_t maxlen)
+{
+    char *p;
+    return ((p = memchr(s, '\0', maxlen)) ? p - s : maxlen);
+}
+#endif
+
 #define PARSE_ERROR_FRAGMENT_LEN 32
 #ifdef RBIMPL_ATTR_NORETURN
 RBIMPL_ATTR_NORETURN()
@@ -439,11 +447,11 @@ static void raise_parse_error(const char *format, const char *start)
 
 
 
-#line 465 "parser.rl"
+#line 473 "parser.rl"
 
 
 
-#line 447 "parser.c"
+#line 455 "parser.c"
 enum {JSON_object_start = 1};
 enum {JSON_object_first_final = 32};
 enum {JSON_object_error = 0};
@@ -451,7 +459,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 505 "parser.rl"
+#line 513 "parser.rl"
 
 
 #define PUSH(result) rvalue_stack_push(json->stack, result, &json->stack_handle, &json->stack)
@@ -467,14 +475,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     long stack_head = json->stack->head;
 
 
-#line 471 "parser.c"
+#line 479 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 520 "parser.rl"
+#line 528 "parser.rl"
 
-#line 478 "parser.c"
+#line 486 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -503,7 +511,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 484 "parser.rl"
+#line 492 "parser.rl"
 	{
         char *np;
         json->parsing_name = true;
@@ -519,7 +527,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 523 "parser.c"
+#line 531 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -586,7 +594,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 473 "parser.rl"
+#line 481 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, result, current_nesting);
         if (np == NULL) {
@@ -600,20 +608,20 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 604 "parser.c"
+#line 612 "parser.c"
 	_widec = (*p);
 	if ( (*p) < 13 ) {
 		if ( (*p) > 9 ) {
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -621,26 +629,26 @@ case 9:
 			if ( 32 <= (*p) && (*p) <= 32 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) > 44 ) {
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -661,14 +669,14 @@ case 9:
 		goto st10;
 	goto st0;
 tr4:
-#line 495 "parser.rl"
+#line 503 "parser.rl"
 	{ p--; {p++; cs = 32; goto _out;} }
 	goto st32;
 st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 672 "parser.c"
+#line 680 "parser.c"
 	goto st0;
 st10:
 	if ( ++p == pe )
@@ -770,13 +778,13 @@ case 20:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -795,20 +803,20 @@ case 21:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -831,13 +839,13 @@ case 22:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -845,19 +853,19 @@ case 22:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -881,20 +889,20 @@ case 23:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 482 "parser.rl"
+#line 490 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1008,7 +1016,7 @@ case 31:
 	_out: {}
 	}
 
-#line 521 "parser.rl"
+#line 529 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         long count = json->stack->head - stack_head;
@@ -1059,7 +1067,7 @@ case 31:
 }
 
 
-#line 1063 "parser.c"
+#line 1071 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -1067,7 +1075,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 654 "parser.rl"
+#line 662 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1075,14 +1083,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1079 "parser.c"
+#line 1087 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 661 "parser.rl"
+#line 669 "parser.rl"
 
-#line 1086 "parser.c"
+#line 1094 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1116,7 +1124,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 599 "parser.rl"
+#line 607 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) {
@@ -1128,7 +1136,7 @@ tr2:
     }
 	goto st29;
 tr3:
-#line 609 "parser.rl"
+#line 617 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -1148,7 +1156,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 627 "parser.rl"
+#line 635 "parser.rl"
 	{
         char *np;
         json->in_array++;
@@ -1158,7 +1166,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 635 "parser.rl"
+#line 643 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -1166,7 +1174,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 592 "parser.rl"
+#line 600 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -1176,7 +1184,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 585 "parser.rl"
+#line 593 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -1186,19 +1194,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 579 "parser.rl"
+#line 587 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 576 "parser.rl"
+#line 584 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 582 "parser.rl"
+#line 590 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -1207,9 +1215,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 641 "parser.rl"
+#line 649 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 1213 "parser.c"
+#line 1221 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -1450,7 +1458,7 @@ case 28:
 	_out: {}
 	}
 
-#line 662 "parser.rl"
+#line 670 "parser.rl"
 
     if (json->freeze) {
         OBJ_FREEZE(*result);
@@ -1465,7 +1473,7 @@ case 28:
 }
 
 
-#line 1469 "parser.c"
+#line 1477 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -1473,7 +1481,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 683 "parser.rl"
+#line 691 "parser.rl"
 
 
 #define MAX_FAST_INTEGER_SIZE 18
@@ -1513,7 +1521,7 @@ static char *JSON_decode_integer(JSON_Parser *json, char *p, VALUE *result)
 }
 
 
-#line 1517 "parser.c"
+#line 1525 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 6};
 enum {JSON_float_error = 0};
@@ -1521,7 +1529,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 735 "parser.rl"
+#line 743 "parser.rl"
 
 
 static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1530,15 +1538,15 @@ static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *resu
     bool is_float = false;
 
 
-#line 1534 "parser.c"
+#line 1542 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 743 "parser.rl"
+#line 751 "parser.rl"
     json->memo = p;
 
-#line 1542 "parser.c"
+#line 1550 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1578,24 +1586,24 @@ case 6:
 		goto st0;
 	goto tr7;
 tr7:
-#line 727 "parser.rl"
+#line 735 "parser.rl"
 	{ p--; {p++; cs = 7; goto _out;} }
 	goto st7;
 st7:
 	if ( ++p == pe )
 		goto _test_eof7;
 case 7:
-#line 1589 "parser.c"
+#line 1597 "parser.c"
 	goto st0;
 tr8:
-#line 728 "parser.rl"
+#line 736 "parser.rl"
 	{  is_float = true; }
 	goto st3;
 st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1599 "parser.c"
+#line 1607 "parser.c"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto st8;
 	goto st0;
@@ -1614,14 +1622,14 @@ case 8:
 		goto st0;
 	goto tr7;
 tr9:
-#line 728 "parser.rl"
+#line 736 "parser.rl"
 	{  is_float = true; }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 1625 "parser.c"
+#line 1633 "parser.c"
 	switch( (*p) ) {
 		case 43: goto st5;
 		case 45: goto st5;
@@ -1678,7 +1686,7 @@ case 10:
 	_out: {}
 	}
 
-#line 745 "parser.rl"
+#line 753 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         if (!is_float) {
@@ -1734,7 +1742,7 @@ case 10:
 
 
 
-#line 1738 "parser.c"
+#line 1746 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 22};
 enum {JSON_array_error = 0};
@@ -1742,7 +1750,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 825 "parser.rl"
+#line 833 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1755,14 +1763,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     long stack_head = json->stack->head;
 
 
-#line 1759 "parser.c"
+#line 1767 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 837 "parser.rl"
+#line 845 "parser.rl"
 
-#line 1766 "parser.c"
+#line 1774 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -1802,7 +1810,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 805 "parser.rl"
+#line 813 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1817,12 +1825,12 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1821 "parser.c"
+#line 1829 "parser.c"
 	_widec = (*p);
 	if ( 44 <= (*p) && (*p) <= 44 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1869,14 +1877,14 @@ case 7:
 		goto st3;
 	goto st7;
 tr4:
-#line 817 "parser.rl"
+#line 825 "parser.rl"
 	{ p--; {p++; cs = 22; goto _out;} }
 	goto st22;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1880 "parser.c"
+#line 1888 "parser.c"
 	goto st0;
 st8:
 	if ( ++p == pe )
@@ -1944,13 +1952,13 @@ case 13:
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -1958,19 +1966,19 @@ case 13:
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 32 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2009,13 +2017,13 @@ case 14:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2034,20 +2042,20 @@ case 15:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2070,13 +2078,13 @@ case 16:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -2084,19 +2092,19 @@ case 16:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2120,20 +2128,20 @@ case 17:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 823 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2205,7 +2213,7 @@ case 21:
 	_out: {}
 	}
 
-#line 838 "parser.rl"
+#line 846 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         long count = json->stack->head - stack_head;
@@ -2399,7 +2407,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
 }
 
 
-#line 2403 "parser.c"
+#line 2411 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 9};
 enum {JSON_string_error = 0};
@@ -2407,7 +2415,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 1061 "parser.rl"
+#line 1069 "parser.rl"
 
 
 static int
@@ -2428,15 +2436,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 2432 "parser.c"
+#line 2440 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 1081 "parser.rl"
+#line 1089 "parser.rl"
     json->memo = p;
 
-#line 2440 "parser.c"
+#line 2448 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2461,14 +2469,14 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 1043 "parser.rl"
+#line 1051 "parser.rl"
 	{
         *result = json_string_fastpath(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
         p--;
         {p++; cs = 9; goto _out;}
     }
-#line 1036 "parser.rl"
+#line 1044 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2477,7 +2485,7 @@ tr2:
     }
 	goto st9;
 tr6:
-#line 1036 "parser.rl"
+#line 1044 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2489,7 +2497,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 2493 "parser.c"
+#line 2501 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -2577,7 +2585,7 @@ case 8:
 	_out: {}
 	}
 
-#line 1083 "parser.rl"
+#line 1091 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -2730,7 +2738,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 2734 "parser.c"
+#line 2742 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -2738,7 +2746,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 1249 "parser.rl"
+#line 1257 "parser.rl"
 
 
 /*
@@ -2767,16 +2775,16 @@ static VALUE cParser_parse(VALUE self)
     json->stack = &stack;
 
 
-#line 2771 "parser.c"
+#line 2779 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1277 "parser.rl"
+#line 1285 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2780 "parser.c"
+#line 2788 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2810,7 +2818,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1241 "parser.rl"
+#line 1249 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2820,7 +2828,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2824 "parser.c"
+#line 2832 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2909,7 +2917,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1280 "parser.rl"
+#line 1288 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -2945,16 +2953,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     json->stack = &stack;
 
 
-#line 2949 "parser.c"
+#line 2957 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1315 "parser.rl"
+#line 1323 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2958 "parser.c"
+#line 2966 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2988,7 +2996,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1241 "parser.rl"
+#line 1249 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2998,7 +3006,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 3002 "parser.c"
+#line 3010 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -3087,7 +3095,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1318 "parser.rl"
+#line 1326 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -415,6 +415,14 @@ static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *resu
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting);
 
 
+#ifndef HAVE_STRNLEN
+static size_t strnlen(const char *s, size_t maxlen)
+{
+    char *p;
+    return ((p = memchr(s, '\0', maxlen)) ? p - s : maxlen);
+}
+#endif
+
 #define PARSE_ERROR_FRAGMENT_LEN 32
 #ifdef RBIMPL_ATTR_NORETURN
 RBIMPL_ATTR_NORETURN()


### PR DESCRIPTION
json parser fails to start on Solaris 10 because Solaris 10 lacks strnlen().

To add support for Solaris 10, added a check for the existence of strnlen() in ext/json/ext/parser/extconf.rb, and added alternative strnlen() implementation to be used if it is missing.