### PR TITLE
Bump up v2.9.1

### DIFF
--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JSON
-  VERSION = '2.9.0'
+  VERSION = '2.9.1'
 end


### PR DESCRIPTION
For https://github.com/ruby/json/releases/tag/v2.9.1

I will update release workflow next year with [the trusted publisher](https://guides.rubygems.org/trusted-publishing/adding-a-publisher/). We can release new version with update `version.rb`, `git tag v2.9.1` and `git push --tags` after that.