### PR TITLE
Remove Generator::State#_generate

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1068,8 +1068,19 @@ static VALUE cState_partial_generate(VALUE self, VALUE obj, generator_func func,
     return fbuffer_finalize(&buffer);
 }
 
-static VALUE cState_generate(VALUE self, VALUE obj, VALUE io)
+/* call-seq:
+ *   generate(obj) -> String
+ *   generate(obj, anIO) -> anIO
+ *
+ * Generates a valid JSON document from object +obj+ and returns the
+ * result. If no valid JSON document can be created this method raises a
+ * GeneratorError exception.
+ */
+static VALUE cState_generate(int argc, VALUE *argv, VALUE self)
 {
+    rb_check_arity(argc, 1, 2);
+    VALUE obj = argv[0];
+    VALUE io = argc > 1 ? argv[1] : Qnil;
     VALUE result = cState_partial_generate(self, obj, generate_json, io);
     GET_STATE(self);
     (void)state;
@@ -1582,7 +1593,7 @@ void Init_generator(void)
     rb_define_method(cState, "depth=", cState_depth_set, 1);
     rb_define_method(cState, "buffer_initial_length", cState_buffer_initial_length, 0);
     rb_define_method(cState, "buffer_initial_length=", cState_buffer_initial_length_set, 1);
-    rb_define_private_method(cState, "_generate", cState_generate, 2);
+    rb_define_method(cState, "generate", cState_generate, -1);
 
     rb_define_singleton_method(cState, "generate", cState_m_generate, 3);
 

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -134,7 +134,7 @@ public class GeneratorState extends RubyObject {
 
     @JRubyMethod(meta=true)
     public static IRubyObject generate(ThreadContext context, IRubyObject klass, IRubyObject obj, IRubyObject opts, IRubyObject io) {
-        return fromState(context, opts)._generate(context, obj, io);
+        return fromState(context, opts).generate(context, obj, io);
     }
 
     static GeneratorState fromState(ThreadContext context, IRubyObject opts) {
@@ -227,8 +227,8 @@ public class GeneratorState extends RubyObject {
      * the result. If no valid JSON document can be created this method raises
      * a GeneratorError exception.
      */
-    @JRubyMethod(visibility = Visibility.PRIVATE)
-    public IRubyObject _generate(ThreadContext context, IRubyObject obj, IRubyObject io) {
+    @JRubyMethod
+    public IRubyObject generate(ThreadContext context, IRubyObject obj, IRubyObject io) {
         IRubyObject result = Generator.generateJson(context, obj, this, io);
         RuntimeInfo info = RuntimeInfo.forRuntime(context.runtime);
         if (!(result instanceof RubyString)) {
@@ -245,6 +245,11 @@ public class GeneratorState extends RubyObject {
         }
 
         return resultString;
+    }
+
+    @JRubyMethod
+    public IRubyObject generate(ThreadContext context, IRubyObject obj) {
+        return generate(context, obj, context.nil);
     }
 
     @JRubyMethod(name="[]")

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -818,11 +818,7 @@ module JSON
     opts = merge_dump_options(opts, **kwargs) if kwargs
 
     begin
-      if State === opts
-        opts.generate(obj, anIO)
-      else
-        State.generate(obj, opts, anIO)
-      end
+      State.generate(obj, opts, anIO)
     rescue JSON::NestingError
       raise ArgumentError, "exceed depth limit"
     end

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -47,17 +47,6 @@ module JSON
 
         alias_method :merge, :configure
 
-        # call-seq:
-        #   generate(obj) -> String
-        #   generate(obj, anIO) -> anIO
-        #
-        # Generates a valid JSON document from object +obj+ and returns the
-        # result. If no valid JSON document can be created this method raises a
-        # GeneratorError exception.
-        def generate(obj, io = nil)
-          _generate(obj, io)
-        end
-
         # call-seq: to_h
         #
         # Returns the configuration instance variables as a hash, that can be

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -97,13 +97,7 @@ module JSON
       # while generating a JSON text from a Ruby data structure.
       class State
         def self.generate(obj, opts = nil, io = nil)
-          string = new(opts).generate(obj)
-          if io
-            io.write(string)
-            io
-          else
-            string
-          end
+          new(opts).generate(obj, io)
         end
 
         # Creates a State object from _opts_, which ought to be Hash to create
@@ -299,7 +293,7 @@ module JSON
         # returns the result. If no valid JSON document can be
         # created this method raises a
         # GeneratorError exception.
-        def generate(obj)
+        def generate(obj, anIO = nil)
           if @indent.empty? and @space.empty? and @space_before.empty? and @object_nl.empty? and @array_nl.empty? and
               !@ascii_only and !@script_safe and @max_nesting == 0 and !@strict
             result = generate_json(obj, ''.dup)
@@ -310,7 +304,12 @@ module JSON
             "source sequence #{result.inspect} is illegal/malformed utf-8",
             obj
           )
-          result
+          if anIO
+            anIO.write(result)
+            anIO
+          else
+            result
+          end
         end
 
         # Handles @allow_nan, @buffer_initial_length, other ivars must be the default value (see above)


### PR DESCRIPTION
It's not necessary as it just delegating from `Generator::State#generate`. We can handle the arity directly in the extension in C or Java, and in Ruby for TruffleRuby.