### PR TITLE
Refactor JSON::Ext::Parser to split configuration and parsing state

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,8 +40,8 @@ EXT_GENERATOR_DL  = "#{EXT_GENERATOR_DIR}/generator.#{CONFIG['DLEXT']}"
 EXT_GENERATOR_SRC = "#{EXT_GENERATOR_DIR}/generator.c"
 
 JAVA_DIR            = "java/src/json/ext"
-JAVA_RAGEL_PATH     = "#{JAVA_DIR}/Parser.rl"
-JAVA_PARSER_SRC     = "#{JAVA_DIR}/Parser.java"
+JAVA_RAGEL_PATH     = "#{JAVA_DIR}/ParserConfig.rl"
+JAVA_PARSER_SRC     = "#{JAVA_DIR}/ParserConfig.java"
 JAVA_SOURCES        = FileList["#{JAVA_DIR}/*.java"]
 JAVA_CLASSES        = []
 JRUBY_PARSER_JAR    = File.expand_path("lib/json/ext/parser.jar")
@@ -95,9 +95,9 @@ end
 file JAVA_PARSER_SRC => JAVA_RAGEL_PATH do
   cd JAVA_DIR do
     if RAGEL_CODEGEN == 'ragel'
-      sh "ragel Parser.rl -J -o Parser.java"
+      sh "ragel ParserConfig.rl -J -o ParserConfig.java"
     else
-      sh "ragel -x Parser.rl | #{RAGEL_CODEGEN} -J"
+      sh "ragel -x ParserConfig.rl | #{RAGEL_CODEGEN} -J"
     end
   end
 end

--- a/java/src/json/ext/ParserService.java
+++ b/java/src/json/ext/ParserService.java
@@ -25,10 +25,10 @@ public class ParserService implements BasicLibraryService {
 
         info.jsonModule = new WeakReference<RubyModule>(runtime.defineModule("JSON"));
         RubyModule jsonExtModule = info.jsonModule.get().defineModuleUnder("Ext");
-        RubyClass parserClass =
-            jsonExtModule.defineClassUnder("Parser", runtime.getObject(),
-                                           Parser.ALLOCATOR);
-        parserClass.defineAnnotatedMethods(Parser.class);
+        RubyClass parserConfigClass =
+            jsonExtModule.defineClassUnder("ParserConfig", runtime.getObject(),
+                                           ParserConfig.ALLOCATOR);
+        parserConfigClass.defineAnnotatedMethods(ParserConfig.class);
         return true;
     }
 }

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -232,12 +232,13 @@ module JSON
   # - Option +max_nesting+, if not provided, defaults to +false+,
   #   which disables checking for nesting depth.
   # - Option +allow_nan+, if not provided, defaults to +true+.
-  def parse!(source, opts = {})
-    opts = {
+  def parse!(source, opts = nil)
+    options = {
       :max_nesting  => false,
       :allow_nan    => true
-    }.merge(opts)
-    Parser.new(source, **(opts||{})).parse
+    }
+    options.merge!(opts) if opts
+    Parser.new(source, options).parse
   end
 
   # :call-seq:
@@ -258,7 +259,7 @@ module JSON
   #   JSON.parse!(File.read(path, opts))
   #
   # See method #parse!
-  def load_file!(filespec, opts = {})
+  def load_file!(filespec, opts = nil)
     parse!(File.read(filespec, encoding: Encoding::UTF_8), opts)
   end
 

--- a/lib/json/ext.rb
+++ b/lib/json/ext.rb
@@ -6,15 +6,36 @@ module JSON
   # This module holds all the modules/classes that implement JSON's
   # functionality as C extensions.
   module Ext
+    class Parser
+      class << self
+        def parse(...)
+          new(...).parse
+        end
+      end
+
+      def initialize(source, opts = nil)
+        @source = source
+        @config = Config.new(opts)
+      end
+
+      def source
+        @source.dup
+      end
+
+      def parse
+        @config.parse(@source)
+      end
+    end
+
+    require 'json/ext/parser'
+    Ext::Parser::Config = Ext::ParserConfig
+    JSON.parser = Ext::Parser
+
     if RUBY_ENGINE == 'truffleruby'
-      require 'json/ext/parser'
       require 'json/truffle_ruby/generator'
-      JSON.parser = Parser
       JSON.generator = ::JSON::TruffleRuby::Generator
     else
-      require 'json/ext/parser'
       require 'json/ext/generator'
-      JSON.parser = Parser
       JSON.generator = Generator
     end
   end

--- a/test/json/json_ext_parser_test.rb
+++ b/test/json/json_ext_parser_test.rb
@@ -6,11 +6,11 @@ class JSONExtParserTest < Test::Unit::TestCase
 
   def test_allocate
     parser = JSON::Ext::Parser.new("{}")
-    assert_raise(TypeError, '[ruby-core:35079]') do
-      parser.__send__(:initialize, "{}")
-    end
+    parser.__send__(:initialize, "{}")
+    assert_equal "{}", parser.source
+
     parser = JSON::Ext::Parser.allocate
-    assert_raise(TypeError, '[ruby-core:35079]') { parser.source }
+    assert_nil parser.source
   end
 
   def test_error_messages


### PR DESCRIPTION
Ref: https://github.com/ruby/json/pull/718

The existing `Parser` interface is pretty bad, as it forces to instantiate a new instance for each document.

Instead it's preferable to only take the config and do all the initialization needed, and then keep the parsing state on the stack on in ephemeral memory.

This refactor makes the `JSON::Coder` pull request much easier to implement in a performant way.