### PR TITLE
WIP ARM Neon/AVX2 SIMD implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Gemfile.lock
 .DS_Store
 */**/Makefile
 */**/*.o
+*/**/extconf.h
 */**/*.class
 */**/*.jar
 .byebug_history

--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ end
 
 file EXT_GENERATOR_DL => EXT_GENERATOR_SRC do
   cd EXT_GENERATOR_DIR do
-    ruby 'extconf.rb'
+    ruby "extconf.rb #{ENV['JSON_GENERATOR_CONFIGURE_OPTS']}"
     sh MAKE
   end
   cp "#{EXT_GENERATOR_DIR}/generator.#{CONFIG['DLEXT']}", EXT_ROOT_DIR

--- a/benchmark/encoder-simple.rb
+++ b/benchmark/encoder-simple.rb
@@ -1,0 +1,58 @@
+require "benchmark/ips"
+require "json"
+require "date"
+require "oj"
+
+Oj.default_options = Oj.default_options.merge(mode: :compat)
+
+if ENV["ONLY"]
+  RUN = ENV["ONLY"].split(/[,: ]/).map{|x| [x.to_sym, true] }.to_h
+  RUN.default = false
+elsif ENV["EXCEPT"]
+  RUN = ENV["EXCEPT"].split(/[,: ]/).map{|x| [x.to_sym, false] }.to_h
+  RUN.default = true
+else
+  RUN = Hash.new(true)
+end
+
+def implementations(ruby_obj)
+  state = JSON::State.new(JSON.dump_default_options)
+  {
+    json: ["json", proc { JSON.generate(ruby_obj) }],
+    oj: ["oj", proc { Oj.dump(ruby_obj) }],
+  }
+end
+
+def benchmark_encoding(benchmark_name, ruby_obj, check_expected: true, except: [])
+  json_output = JSON.dump(ruby_obj)
+  puts "== Encoding #{benchmark_name} (#{json_output.bytesize} bytes)"
+
+  impls = implementations(ruby_obj).select { |name| RUN[name] }
+  except.each { |i| impls.delete(i) }
+
+  Benchmark.ips do |x|
+    expected = ::JSON.dump(ruby_obj) if check_expected
+    impls.values.each do |name, block|
+      begin
+        result = block.call
+        if check_expected && expected != result
+          puts "#{name} does not match expected output. Skipping"
+          puts "Expected:" + '-' * 40
+          puts expected
+          puts "Actual:" + '-' * 40
+          puts result
+          puts '-' * 40
+          next
+        end
+      rescue => error
+        puts "#{name} unsupported (#{error})"
+        next
+      end
+      x.report(name, &block)
+    end
+    x.compare!(order: :baseline)
+  end
+  puts
+end
+
+benchmark_encoding "long string", (["this is a test of the emergency broadcast system."*5]*500)

--- a/ext/json/ext/generator/extconf.h
+++ b/ext/json/ext/generator/extconf.h
@@ -1,8 +1,0 @@
-#ifndef EXTCONF_H
-#define EXTCONF_H
-#define JSON_GENERATOR 1
-#define ENABLE_SIMD 1
-#define HAVE_ARM_NEON_H 1
-#define HAVE_TYPE_UINT8X16_T 1
-#define HAVE_TYPE_UINT8X8_T 1
-#endif

--- a/ext/json/ext/generator/extconf.h
+++ b/ext/json/ext/generator/extconf.h
@@ -1,8 +1,7 @@
 #ifndef EXTCONF_H
 #define EXTCONF_H
 #define JSON_GENERATOR 1
+#define HAVE_X86INTRIN_H 1
+#define HAVE_TYPE___M128I 1
 #define ENABLE_SIMD 1
-#define HAVE_ARM_NEON_H 1
-#define HAVE_TYPE_UINT8X16_T 1
-#define HAVE_TYPE_UINT8X8_T 1
 #endif

--- a/ext/json/ext/generator/extconf.h
+++ b/ext/json/ext/generator/extconf.h
@@ -1,7 +1,8 @@
 #ifndef EXTCONF_H
 #define EXTCONF_H
 #define JSON_GENERATOR 1
-#define HAVE_X86INTRIN_H 1
-#define HAVE_TYPE___M128I 1
 #define ENABLE_SIMD 1
+#define HAVE_ARM_NEON_H 1
+#define HAVE_TYPE_UINT8X16_T 1
+#define HAVE_TYPE_UINT8X8_T 1
 #endif

--- a/ext/json/ext/generator/extconf.h
+++ b/ext/json/ext/generator/extconf.h
@@ -1,0 +1,8 @@
+#ifndef EXTCONF_H
+#define EXTCONF_H
+#define JSON_GENERATOR 1
+#define ENABLE_SIMD 1
+#define HAVE_ARM_NEON_H 1
+#define HAVE_TYPE_UINT8X16_T 1
+#define HAVE_TYPE_UINT8X8_T 1
+#endif

--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -6,5 +6,17 @@ if RUBY_ENGINE == 'truffleruby'
 else
   append_cflags("-std=c99")
   $defs << "-DJSON_GENERATOR"
+
+  if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
+    # Try to compile a small program using NEON instructions
+    have_header('arm_neon.h') && try_compile(<<~'END_SRC')
+      #include <arm_neon.h>
+      int main() {
+          uint8x16_t test = vdupq_n_u8(32);
+          return 0;
+      }
+    END_SRC
+  end
+
   create_makefile 'json/ext/generator'
 end

--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -7,16 +7,31 @@ else
   append_cflags("-std=c99")
   $defs << "-DJSON_GENERATOR"
 
-  if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
-    # Try to compile a small program using NEON instructions
-    have_header('arm_neon.h') && try_compile(<<~'END_SRC')
-      #include <arm_neon.h>
-      int main() {
-          uint8x16_t test = vdupq_n_u8(32);
-          return 0;
-      }
-    END_SRC
+  if enable_config('use-simd', default=true)
+    $defs.push("-DENABLE_SIMD")
+
+    if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
+      # Try to compile a small program using NEON instructions
+      if have_header('arm_neon.h')
+        have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
+          #include <arm_neon.h>
+          int main() {
+              uint8x16_t test = vdupq_n_u8(32);
+              return 0;
+          }
+        SRC
+
+        have_type('uint8x8_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
+            #include <arm_neon.h>
+            int main() {
+                uint8x8_t test = vdup_n_u8(32);
+                return 0;
+            }
+        SRC
+        end
+    end
   end
 
+  create_header
   create_makefile 'json/ext/generator'
 end

--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -31,9 +31,7 @@ else
         end
       elsif have_header('x86intrin.h')
         
-        # This is currently hardcoded to false as using m256 seems significantly slower on my machine.
-        # TODO make this configurable
-        if false && have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+        if have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
           #include <x86intrin.h>
           int main() {
               __m256i test = _mm256_set1_epi8(32);
@@ -41,18 +39,20 @@ else
           }
           SRC
           $defs.push("-DENABLE_SIMD")
-          append_cflags('-mavx2')
-        elsif have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+        end
+        
+        if have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
           #include <x86intrin.h>
           int main() {
               __m128i test = _mm_set1_epi8(32);
               return 0;
           }
           SRC
-            $defs.push("-DENABLE_SIMD")
-            append_cflags('-mavx2')
+            $defs.push("-DENABLE_SIMD") unless $defs.include?('-DENABLE_SIMD')
         end
       end
+
+      have_header('cpuid.h')
   end
 
   create_header

--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -8,9 +8,9 @@ else
   $defs << "-DJSON_GENERATOR"
 
   if enable_config('use-simd', default=true)
-    $defs.push("-DENABLE_SIMD")
-
     if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
+      $defs.push("-DENABLE_SIMD")
+
       # Try to compile a small program using NEON instructions
       if have_header('arm_neon.h')
         have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
@@ -29,7 +29,30 @@ else
             }
         SRC
         end
-    end
+      elsif have_header('x86intrin.h')
+        
+        # This is currently hardcoded to false as using m256 seems significantly slower on my machine.
+        # TODO make this configurable
+        if false && have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+          #include <x86intrin.h>
+          int main() {
+              __m256i test = _mm256_set1_epi8(32);
+              return 0;
+          }
+          SRC
+          $defs.push("-DENABLE_SIMD")
+          append_cflags('-mavx2')
+        elsif have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+          #include <x86intrin.h>
+          int main() {
+              __m128i test = _mm_set1_epi8(32);
+              return 0;
+          }
+          SRC
+            $defs.push("-DENABLE_SIMD")
+            append_cflags('-mavx2')
+        end
+      end
   end
 
   create_header

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -4,8 +4,6 @@
 #include <math.h>
 #include <ctype.h>
 
-#include "extconf.h"
-
 #ifdef HAVE_ARM_NEON_H
 #include <arm_neon.h>
 #endif

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -240,7 +240,7 @@ static void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str)
 
     unsigned long beg = 0, pos = 0;
 
-#ifdef HAVE_ARM_NEON_H
+#ifdef ENABLE_SIMD
     /*
      * The code below implements an SIMD-based algorithm to determine if N bytes at a time
      * need to be escaped. 
@@ -346,7 +346,7 @@ static void convert_UTF8_to_JSON_script_safe(FBuffer *out_buffer, VALUE str)
 
 #define FLUSH_POS(bytes) if (pos > beg) { fbuffer_append(out_buffer, &ptr[beg], pos - beg); } pos += bytes; beg = pos;
 
-#ifdef HAVE_ARM_NEON_H
+#ifdef ENABLE_SIMD
     /*
     * This works almost exactly the same as what is described above. The difference in this case comes after we know
     * there is a byte to be escaped. In the previous case, all bytes were handled the same way. In this case, however,
@@ -522,7 +522,7 @@ static void convert_UTF8_to_ASCII_only_JSON(FBuffer *out_buffer, VALUE str, cons
 
     unsigned long beg = 0, pos = 0;
 
-#ifdef HAVE_ARM_NEON_H
+#ifdef ENABLE_SIMD
     const simd_vec_type lower_bound   = simd_vec_from_byte(' '); 
     const simd_vec_type upper_bound   = simd_vec_from_byte('~');
     const simd_vec_type backslash     = simd_vec_from_byte('\\');

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -254,22 +254,18 @@ static void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str)
         uint8x16_t has_backslash = vceqq_u8(chunk, backslash);
         uint8x16_t has_dblquote = vceqq_u8(chunk, dblquote);
 
-        uint8x16_t invalid = too_low;
+        uint8x16_t needs_escape = too_low;
         uint8x16_t has_escaped_char = vorrq_u8(has_backslash, has_dblquote);
         
-        invalid = vorrq_u8(invalid, has_escaped_char);
+        needs_escape = vorrq_u8(needs_escape, has_escaped_char);
 
-        if (vmaxvq_u8(invalid) == 0) {
+        if (vmaxvq_u8(needs_escape) == 0) {
             pos += 16;
             continue;
         }
 
-        uint8x16_t tmp = vandq_u8(too_low, vdupq_n_u8(0x1));
-        tmp = vorrq_u8(tmp, vandq_u8(has_backslash, vdupq_n_u8(0x2)));
-        tmp = vorrq_u8(tmp, vandq_u8(has_dblquote, vdupq_n_u8(0x4)));
-
         uint8_t arr[16];
-        vst1q_u8(arr, tmp);
+        vst1q_u8(arr, needs_escape);
         for (int i = 0; i < 16; i++) {
             unsigned char ch = ptr[pos];
             unsigned char ch_len = arr[i];

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -20,6 +20,14 @@
 #define simd_vec_and             vandq_u8
 #define simd_vec_max             vmaxvq_u8
 
+inline int smd_vec_any_set(uint8x16_t vec) {
+    return vmaxvq_u8(vec) != 0;
+}
+
+inline int smd_vec_all_zero(uint8x16_t vec) {
+    return vmaxvq_u8(vec) == 0;
+}
+
 #elif HAVE_TYPE_UINT8X8_T
 
 #define SIMD_VEC_STRIDE          8
@@ -34,7 +42,132 @@
 #define simd_vec_and             vand_u8
 #define simd_vec_max             vmaxv_u8
 
+inline int smd_vec_any_set(uint8x8_t vec) {
+    return vmaxv_u8(vec) != 0;
+}
+
+inline int smd_vec_all_zero(uint8x8_t vec) {
+    return vmaxv_u8(vec) == 0;
+}
+
 #endif /* HAVE_TYPE_UINT8X16_T */
 #endif /* HAVE_ARM_NEON_H */
 
+#ifdef HAVE_X86INTRIN_H
+#include <x86intrin.h>
+
+#ifdef HAVE_TYPE___M256I
+
+#define SIMD_VEC_STRIDE             32
+
+#define _mm256_cmpge_epu8(a, b) _mm256_cmpeq_epi8(_mm256_max_epu8(a, b), a)
+#define _mm256_cmple_epu8(a, b) _mm256_cmpge_epu8(b, a)
+#define _mm256_cmpgt_epu8(a, b) _mm256_xor_si256(_mm256_cmple_epu8(a, b), _mm256_set1_epi8(-1))
+#define _mm256_cmplt_epu8(a, b) _mm256_cmpgt_epu8(b, a)
+
+#define simd_vec_type                __m256i
+#define simd_vec_from_byte           _mm256_set1_epi8
+#define simd_vec_load_from_mem(x)    _mm256_loadu_si256((__m256i const*) x)
+#define simd_vec_to_memory(mem, vec) _mm256_storeu_si256((__m256i *) mem, (__m256i) vec)
+#define simd_vec_eq                  _mm256_cmpeq_epi8
+#define simd_vec_lt(a,b)             _mm256_cmplt_epu8(a, b)
+#define simd_vec_gt(a,b)             _mm256_cmpgt_epu8(a, b)
+#define simd_vec_or                  _mm256_or_si256
+#define simd_vec_and                 _mm256_and_si256
+#define simd_vec_max                 _mm256_max_epu8
+
+void print_simd_vec(simd_vec_type vec) {
+    alignas(32) unsigned char bytes[32];
+    _mm256_storeu_si256((__m256i *) bytes, vec);
+    printf("SIMD vector:\n\t[");
+    for(int i=0; i< 32; i++) {
+        printf(" %02x ", bytes[i]);
+    }
+    printf("]\n");
+}
+
+void print_simd_vec1(const char *prefix, simd_vec_type vec) {
+    alignas(32) unsigned char bytes[32];
+    _mm256_storeu_si256((__m256i *) bytes, vec);
+    printf("%s:\n\t[", prefix);
+    for(int i=0; i< 32; i++) {
+        printf(" %02x ", bytes[i]);
+    }
+    printf("]\n");
+}
+
+int simd_vec_any_set(__m256i vec) {
+    // print_simd_vec1("simd_vec_any_set vec", vec);
+    __m256i zero = _mm256_setzero_si256();
+    __m256i cmp  = _mm256_cmpeq_epi8(vec, zero);
+    int mask     = _mm256_movemask_epi8(cmp);
+    return mask != 0xFFFF;
+}
+
+int simd_vec_all_zero(__m256i vec) {
+    // print_simd_vec1("simd_vec_any_set vec", vec);
+    __m256i zero = _mm256_setzero_si256();
+    __m256i cmp  = _mm256_cmpeq_epi8(vec, zero);
+    int mask     = _mm256_movemask_epi8(cmp);
+    return mask == 0xFFFF;
+}
+
+#elif HAVE_TYPE___M128I
+#define SIMD_VEC_STRIDE          16
+
+#define _mm_cmpge_epu8(a, b) _mm_cmpeq_epi8(_mm_max_epu8(a, b), a)
+#define _mm_cmple_epu8(a, b) _mm_cmpge_epu8(b, a)
+#define _mm_cmpgt_epu8(a, b) _mm_xor_si128(_mm_cmple_epu8(a, b), _mm_set1_epi8(-1))
+#define _mm_cmplt_epu8(a, b) _mm_cmpgt_epu8(b, a)
+
+#define simd_vec_type               __m128i
+#define simd_vec_from_byte          _mm_set1_epi8
+#define simd_vec_load_from_mem(x)   _mm_lddqu_si128((__m128i const*) x)
+#define simd_vec_to_memory(mem, vec) _mm_storeu_si128((__m128i *) mem, (__m128i) vec)
+#define simd_vec_eq                 _mm_cmpeq_epi8
+#define simd_vec_lt(a,b)            _mm_cmplt_epu8(a, b)
+#define simd_vec_gt(a,b)            _mm_cmpgt_epu8(a, b)
+#define simd_vec_or                 _mm_or_si128
+#define simd_vec_and                _mm_and_si128
+#define simd_vec_max                _mm_max_epi8
+
+
+
+void print_simd_vec(simd_vec_type vec) {
+    alignas(16) unsigned char bytes[16];
+    _mm_store_si128((__m128i *) bytes, vec);
+    printf("SIMD vector:\n\t[");
+    for(int i=0; i< 16; i++) {
+        printf(" %02x ", bytes[i]);
+    }
+    printf("]\n");
+}
+
+void print_simd_vec1(const char *prefix, simd_vec_type vec) {
+    alignas(16) unsigned char bytes[16];
+    _mm_store_si128((__m128i *) bytes, vec);
+    printf("%s:\n\t[", prefix);
+    for(int i=0; i< 16; i++) {
+        printf(" %02x ", bytes[i]);
+    }
+    printf("]\n");
+}
+
+int simd_vec_any_set(__m128i vec) {
+    // print_simd_vec1("simd_vec_any_set vec", vec);
+    __m128i zero = _mm_setzero_si128();
+    __m128i cmp  = _mm_cmpeq_epi8(vec, zero);
+    int mask     = _mm_movemask_epi8(cmp);
+    return mask != 0xFFFF;
+}
+
+int simd_vec_all_zero(__m128i vec) {
+    __m128i zero = _mm_setzero_si128();
+    __m128i cmp  = _mm_cmpeq_epi8(vec, zero);
+    int mask     = _mm_movemask_epi8(cmp);
+    return mask  == 0xFFFF;
+}
+
+#endif /* HAVE_TYPE___M256 */
+#endif /* HAVE_X86INTRIN_H */
 #endif /* ENABLE_SIMD */

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -1,0 +1,40 @@
+#include "extconf.h"
+
+#ifdef ENABLE_SIMD
+
+#ifdef HAVE_ARM_NEON_H
+#include <arm_neon.h>
+
+#ifdef HAVE_TYPE_UINT8X16_T
+
+#define SIMD_VEC_STRIDE          16
+
+#define simd_vec_type            uint8x16_t
+#define simd_vec_from_byte       vdupq_n_u8
+#define simd_vec_load_from_mem   vld1q_u8
+#define simd_vec_to_memory       vst1q_u8
+#define simd_vec_eq              vceqq_u8
+#define simd_vec_lt              vcltq_u8
+#define simd_vec_gt              vcgtq_u8
+#define simd_vec_or              vorrq_u8
+#define simd_vec_and             vandq_u8
+#define simd_vec_max             vmaxvq_u8
+
+#elif HAVE_TYPE_UINT8X8_T
+
+#define SIMD_VEC_STRIDE          8
+#define simd_vec_type            uint8x8_t
+#define simd_vec_from_byte       vdup_n_u8
+#define simd_vec_load_from_mem   vld1_u8
+#define simd_vec_to_memory       vst1_u8
+#define simd_vec_eq              vceq_u8
+#define simd_vec_lt              vclt_u8
+#define simd_vec_gt              vcgt_u8
+#define simd_vec_or              vorr_u8
+#define simd_vec_and             vand_u8
+#define simd_vec_max             vmaxv_u8
+
+#endif /* HAVE_TYPE_UINT8X16_T */
+#endif /* HAVE_ARM_NEON_H */
+
+#endif /* ENABLE_SIMD */

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -20,11 +20,11 @@
 #define simd_vec_and             vandq_u8
 #define simd_vec_max             vmaxvq_u8
 
-inline int smd_vec_any_set(uint8x16_t vec) {
+inline int simd_vec_any_set(uint8x16_t vec) {
     return vmaxvq_u8(vec) != 0;
 }
 
-inline int smd_vec_all_zero(uint8x16_t vec) {
+inline int simd_vec_all_zero(uint8x16_t vec) {
     return vmaxvq_u8(vec) == 0;
 }
 

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -1,173 +1,71 @@
 #include "extconf.h"
 
+typedef enum {
+    SIMD_NONE,
+    SIMD_NEON,
+    SIMD_SSE42,
+    SIMD_AVX2
+} SIMD_Implementation;
+
 #ifdef ENABLE_SIMD
 
-#ifdef HAVE_ARM_NEON_H
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) || defined(_M_ARM64)
 #include <arm_neon.h>
+
+#define FIND_SIMD_IMPLEMENTATION_DEFINED 1
+SIMD_Implementation find_simd_implementation() {
+    return SIMD_NEON;
+}
+
+#define HAVE_SIMD_NEON 1
 
 #ifdef HAVE_TYPE_UINT8X16_T
 
-#define SIMD_VEC_STRIDE          16
-
-#define simd_vec_type            uint8x16_t
-#define simd_vec_from_byte       vdupq_n_u8
-#define simd_vec_load_from_mem   vld1q_u8
-#define simd_vec_to_memory       vst1q_u8
-#define simd_vec_eq              vceqq_u8
-#define simd_vec_lt              vcltq_u8
-#define simd_vec_gt              vcgtq_u8
-#define simd_vec_or              vorrq_u8
-#define simd_vec_and             vandq_u8
-#define simd_vec_max             vmaxvq_u8
-
-inline int simd_vec_any_set(uint8x16_t vec) {
-    return vmaxvq_u8(vec) != 0;
-}
-
-inline int simd_vec_all_zero(uint8x16_t vec) {
-    return vmaxvq_u8(vec) == 0;
-}
-
-#elif HAVE_TYPE_UINT8X8_T
-
-#define SIMD_VEC_STRIDE          8
-#define simd_vec_type            uint8x8_t
-#define simd_vec_from_byte       vdup_n_u8
-#define simd_vec_load_from_mem   vld1_u8
-#define simd_vec_to_memory       vst1_u8
-#define simd_vec_eq              vceq_u8
-#define simd_vec_lt              vclt_u8
-#define simd_vec_gt              vcgt_u8
-#define simd_vec_or              vorr_u8
-#define simd_vec_and             vand_u8
-#define simd_vec_max             vmaxv_u8
-
-inline int smd_vec_any_set(uint8x8_t vec) {
-    return vmaxv_u8(vec) != 0;
-}
-
-inline int smd_vec_all_zero(uint8x8_t vec) {
-    return vmaxv_u8(vec) == 0;
-}
-
 #endif /* HAVE_TYPE_UINT8X16_T */
-#endif /* HAVE_ARM_NEON_H */
+#endif /* ARM Neon Support.*/
 
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+
+#define HAVE_SIMD_X86_64 1 
 #ifdef HAVE_X86INTRIN_H
 #include <x86intrin.h>
 
+#define HAVE_SIMD_X86_64 1
+
+#ifdef HAVE_CPUID_H
+#define FIND_SIMD_IMPLEMENTATION_DEFINED 1
+
+#include <cpuid.h>
+#endif 
+
+SIMD_Implementation find_simd_implementation(void) {
+
+#if defined(__GNUC__ ) || defined(__clang__)
+#ifdef __GNUC__ 
+    __builtin_cpu_init();
+#endif /* __GNUC__  */
+
 #ifdef HAVE_TYPE___M256I
-
-#define SIMD_VEC_STRIDE             32
-
-#define _mm256_cmpge_epu8(a, b) _mm256_cmpeq_epi8(_mm256_max_epu8(a, b), a)
-#define _mm256_cmple_epu8(a, b) _mm256_cmpge_epu8(b, a)
-#define _mm256_cmpgt_epu8(a, b) _mm256_xor_si256(_mm256_cmple_epu8(a, b), _mm256_set1_epi8(-1))
-#define _mm256_cmplt_epu8(a, b) _mm256_cmpgt_epu8(b, a)
-
-#define simd_vec_type                __m256i
-#define simd_vec_from_byte           _mm256_set1_epi8
-#define simd_vec_load_from_mem(x)    _mm256_loadu_si256((__m256i const*) x)
-#define simd_vec_to_memory(mem, vec) _mm256_storeu_si256((__m256i *) mem, (__m256i) vec)
-#define simd_vec_eq                  _mm256_cmpeq_epi8
-#define simd_vec_lt(a,b)             _mm256_cmplt_epu8(a, b)
-#define simd_vec_gt(a,b)             _mm256_cmpgt_epu8(a, b)
-#define simd_vec_or                  _mm256_or_si256
-#define simd_vec_and                 _mm256_and_si256
-#define simd_vec_max                 _mm256_max_epu8
-
-void print_simd_vec(simd_vec_type vec) {
-    alignas(32) unsigned char bytes[32];
-    _mm256_storeu_si256((__m256i *) bytes, vec);
-    printf("SIMD vector:\n\t[");
-    for(int i=0; i< 32; i++) {
-        printf(" %02x ", bytes[i]);
+    if(__builtin_cpu_supports("avx2")) {
+        return SIMD_AVX2;
     }
-    printf("]\n");
-}
+#endif /* #ifdef HAVE_TYPE___M256I */
 
-void print_simd_vec1(const char *prefix, simd_vec_type vec) {
-    alignas(32) unsigned char bytes[32];
-    _mm256_storeu_si256((__m256i *) bytes, vec);
-    printf("%s:\n\t[", prefix);
-    for(int i=0; i< 32; i++) {
-        printf(" %02x ", bytes[i]);
+    // TODO Revisit. I think the SSE version now only uses SSE2 instructions.
+    if (__builtin_cpu_supports("sse4.2")) {
+        return SIMD_SSE42;
     }
-    printf("]\n");
+#endif /* __GNUC__ || __clang__*/
+
+    return SIMD_NONE;
 }
 
-int simd_vec_any_set(__m256i vec) {
-    // print_simd_vec1("simd_vec_any_set vec", vec);
-    __m256i zero = _mm256_setzero_si256();
-    __m256i cmp  = _mm256_cmpeq_epi8(vec, zero);
-    int mask     = _mm256_movemask_epi8(cmp);
-    return mask != 0xFFFF;
-}
-
-int simd_vec_all_zero(__m256i vec) {
-    // print_simd_vec1("simd_vec_any_set vec", vec);
-    __m256i zero = _mm256_setzero_si256();
-    __m256i cmp  = _mm256_cmpeq_epi8(vec, zero);
-    int mask     = _mm256_movemask_epi8(cmp);
-    return mask == 0xFFFF;
-}
-
-#elif HAVE_TYPE___M128I
-#define SIMD_VEC_STRIDE          16
-
-#define _mm_cmpge_epu8(a, b) _mm_cmpeq_epi8(_mm_max_epu8(a, b), a)
-#define _mm_cmple_epu8(a, b) _mm_cmpge_epu8(b, a)
-#define _mm_cmpgt_epu8(a, b) _mm_xor_si128(_mm_cmple_epu8(a, b), _mm_set1_epi8(-1))
-#define _mm_cmplt_epu8(a, b) _mm_cmpgt_epu8(b, a)
-
-#define simd_vec_type               __m128i
-#define simd_vec_from_byte          _mm_set1_epi8
-#define simd_vec_load_from_mem(x)   _mm_lddqu_si128((__m128i const*) x)
-#define simd_vec_to_memory(mem, vec) _mm_storeu_si128((__m128i *) mem, (__m128i) vec)
-#define simd_vec_eq                 _mm_cmpeq_epi8
-#define simd_vec_lt(a,b)            _mm_cmplt_epu8(a, b)
-#define simd_vec_gt(a,b)            _mm_cmpgt_epu8(a, b)
-#define simd_vec_or                 _mm_or_si128
-#define simd_vec_and                _mm_and_si128
-#define simd_vec_max                _mm_max_epi8
-
-
-
-void print_simd_vec(simd_vec_type vec) {
-    alignas(16) unsigned char bytes[16];
-    _mm_store_si128((__m128i *) bytes, vec);
-    printf("SIMD vector:\n\t[");
-    for(int i=0; i< 16; i++) {
-        printf(" %02x ", bytes[i]);
-    }
-    printf("]\n");
-}
-
-void print_simd_vec1(const char *prefix, simd_vec_type vec) {
-    alignas(16) unsigned char bytes[16];
-    _mm_store_si128((__m128i *) bytes, vec);
-    printf("%s:\n\t[", prefix);
-    for(int i=0; i< 16; i++) {
-        printf(" %02x ", bytes[i]);
-    }
-    printf("]\n");
-}
-
-int simd_vec_any_set(__m128i vec) {
-    // print_simd_vec1("simd_vec_any_set vec", vec);
-    __m128i zero = _mm_setzero_si128();
-    __m128i cmp  = _mm_cmpeq_epi8(vec, zero);
-    int mask     = _mm_movemask_epi8(cmp);
-    return mask != 0xFFFF;
-}
-
-int simd_vec_all_zero(__m128i vec) {
-    __m128i zero = _mm_setzero_si128();
-    __m128i cmp  = _mm_cmpeq_epi8(vec, zero);
-    int mask     = _mm_movemask_epi8(cmp);
-    return mask  == 0xFFFF;
-}
-
-#endif /* HAVE_TYPE___M256 */
 #endif /* HAVE_X86INTRIN_H */
+#endif /* X86_64 Support */
 #endif /* ENABLE_SIMD */
+
+#ifndef FIND_SIMD_IMPLEMENTATION_DEFINED
+SIMD_Implementation find_simd_implementation(void) {
+    return SIMD_NONE;
+}
+#endif

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -424,6 +424,10 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["\\\\.(?i:gif|jpe?g|png)$"]'
     assert_equal json, generate(data)
     #
+    data = [ '\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)$' ]
+    json = '["\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)$"]'
+    assert_equal json, generate(data)
+    #
     data = [ '\\"' ]
     json = '["\\\\\""]'
     assert_equal json, generate(data)
@@ -432,8 +436,20 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["/"]'
     assert_equal json, generate(data)
     #
+    data = [ '////////////////////////////////////////////////////////////////////////////////////' ]
+    json = '["////////////////////////////////////////////////////////////////////////////////////"]'
+    assert_equal json, generate(data)
+    #
     data = [ '/' ]
     json = '["\/"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
+    data = [ '///////////' ]
+    json = '["\/\/\/\/\/\/\/\/\/\/\/"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
+    data = [ '///////////////////////////////////////////////////////' ]
+    json = '["\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/"]'
     assert_equal json, generate(data, :script_safe => true)
     #
     data = [ "\u2028\u2029" ]
@@ -444,8 +460,16 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["ABC \u2028 DEF \u2029 GHI"]'
     assert_equal json, generate(data, :script_safe => true)
     #
+    data = [ "ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI" ]
+    json = '["ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
     data = [ "/\u2028\u2029" ]
     json = '["\/\u2028\u2029"]'
+    assert_equal json, generate(data, :escape_slash => true)
+    #
+    data = [ "/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029" ]
+    json = '["\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029"]'
     assert_equal json, generate(data, :escape_slash => true)
     #
     data = ['"']
@@ -459,6 +483,14 @@ class JSONGeneratorTest < Test::Unit::TestCase
     data = ["倩", "瀨"]
     json = '["倩","瀨"]'
     assert_equal json, generate(data, script_safe: true)
+    #
+    data = ["倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨"]
+    json = '["倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨"]'
+    assert_equal json, generate(data, script_safe: true)
+    #
+    data = '["This is a "test" of the emergency broadcast system."]'
+    json = "\"[\\\"This is a \\\"test\\\" of the emergency broadcast system.\\\"]\""
+    assert_equal json, generate(data)
   end
 
   def test_string_subclass


### PR DESCRIPTION
# WORK IN PROGRESS

Initial implementation providing an ARM Neon (and now AVX2) SIMD implementation of the `convert_UTF8_to_JSON*` functions. 

There is still more work to be done on the `convert_UTF8_to_ASCII_only_JSON`. Right now it only uses SIMD to skip the prefix of characters that do not need escaping. I will fix that in the coming days. 

I started the implementation of x86_64 support. Currently using `__m256i` seems _significantly_ slower on my machine. I plan to make it configurable.

Additionally, the algorithm between the ARM Neon and x86_64 (AVX2) is the same. This may not be ideal as there may be better instructions on one/either platform which would be more efficient.

# Benchmarks
My machine is an M1 Macbook Air with 16MB of RAM. 

```
% ruby -v
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
```

I do _not_ have YJIT built. 

## Baseline: code in `master` (at the time fork was created)

```
% ruby -Ilib:ext benchmark/encoder-simple.rb 
== Encoding long string (124001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.465k i/100ms
                  oj     2.089k i/100ms
Calculating -------------------------------------
                json     14.440k (± 2.5%) i/s   (69.25 μs/i) -     73.250k in   5.075975s
                  oj     20.504k (± 1.9%) i/s   (48.77 μs/i) -    104.450k in   5.096055s

Comparison:
                json:    14439.8 i/s
                  oj:    20503.7 i/s - 1.42x  faster
```

## With SIMD

### Benchmark encoding a long string. 
```
% ruby -Ilib:ext benchmark/encoder-simple.rb
== Encoding long string (124001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     3.721k i/100ms
                  oj     2.006k i/100ms
Calculating -------------------------------------
                json     39.497k (± 3.9%) i/s   (25.32 μs/i) -    200.934k in   5.094877s
                  oj     20.486k (± 2.6%) i/s   (48.81 μs/i) -    104.312k in   5.095360s

Comparison:
                json:    39497.0 i/s
                  oj:    20486.2 i/s - 1.93x  slower
```

### Before and After (using the before & after script)

```
== Encoding long string (124001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     4.386k i/100ms
Calculating -------------------------------------
               after     42.103k (± 4.4%) i/s   (23.75 μs/i) -    210.528k in   5.010512s

Comparison:
              before:    14901.3 i/s
               after:    42103.4 i/s - 2.83x  faster
```

### Existing benchmarks
```
== Encoding small mixed (34 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   431.030k i/100ms
                  oj   425.858k i/100ms
Calculating -------------------------------------
                json      4.443M (± 0.8%) i/s  (225.05 ns/i) -     22.414M in   5.044440s
                  oj      4.240M (± 1.2%) i/s  (235.86 ns/i) -     21.293M in   5.022778s

Comparison:
                json:  4443492.7 i/s
                  oj:  4239867.2 i/s - 1.05x  slower


== Encoding small nested array (121 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   202.481k i/100ms
                  oj   173.531k i/100ms
Calculating -------------------------------------
                json      2.060M (± 3.4%) i/s  (485.48 ns/i) -     10.327M in   5.020528s
                  oj      1.740M (± 1.7%) i/s  (574.79 ns/i) -      8.850M in   5.088416s

Comparison:
                json:  2059819.6 i/s
                  oj:  1739779.8 i/s - 1.18x  slower


== Encoding small hash (65 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   440.390k i/100ms
                  oj   485.263k i/100ms
Calculating -------------------------------------
                json      4.432M (± 0.9%) i/s  (225.61 ns/i) -     22.460M in   5.067690s
                  oj      4.834M (± 1.0%) i/s  (206.86 ns/i) -     24.263M in   5.019614s

Comparison:
                json:  4432356.6 i/s
                  oj:  4834123.7 i/s - 1.09x  faster


== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    79.000 i/100ms
                  oj    36.000 i/100ms
Calculating -------------------------------------
                json    671.096 (±11.8%) i/s    (1.49 ms/i) -      3.318k in   5.004342s
                  oj    350.462 (± 4.3%) i/s    (2.85 ms/i) -      1.764k in   5.042945s

Comparison:
                json:      671.1 i/s
                  oj:      350.5 i/s - 1.91x  slower


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    58.000 i/100ms
                  oj    35.000 i/100ms
Calculating -------------------------------------
                json    657.830 (±18.7%) i/s    (1.52 ms/i) -      3.190k in   5.014119s
                  oj    346.778 (± 3.5%) i/s    (2.88 ms/i) -      1.750k in   5.052975s

Comparison:
                json:      657.8 i/s
                  oj:      346.8 i/s - 1.90x  slower


== Encoding integers (8009 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     7.817k i/100ms
                  oj     7.297k i/100ms
Calculating -------------------------------------
                json     76.183k (± 6.1%) i/s   (13.13 μs/i) -    383.033k in   5.050410s
                  oj     72.630k (± 2.4%) i/s   (13.77 μs/i) -    364.850k in   5.026326s

Comparison:
                json:    76183.3 i/s
                  oj:    72630.4 i/s - same-ish: difference falls within error


== Encoding activitypub.json (52595 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     2.292k i/100ms
                  oj     1.506k i/100ms
Calculating -------------------------------------
                json     22.532k (± 2.9%) i/s   (44.38 μs/i) -    114.600k in   5.090538s
                  oj     15.440k (± 2.2%) i/s   (64.77 μs/i) -     78.312k in   5.074521s

Comparison:
                json:    22531.7 i/s
                  oj:    15440.0 i/s - 1.46x  slower


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   109.000 i/100ms
                  oj    91.000 i/100ms
Calculating -------------------------------------
                json      1.102k (± 1.8%) i/s  (907.47 μs/i) -      5.559k in   5.046287s
                  oj    927.507 (± 1.7%) i/s    (1.08 ms/i) -      4.641k in   5.005234s

Comparison:
                json:     1102.0 i/s
                  oj:      927.5 i/s - 1.19x  slower


== Encoding twitter.json (466906 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   220.000 i/100ms
                  oj   185.000 i/100ms
Calculating -------------------------------------
                json      2.229k (± 2.5%) i/s  (448.54 μs/i) -     11.220k in   5.035750s
                  oj      1.842k (± 3.4%) i/s  (542.90 μs/i) -      9.250k in   5.027607s

Comparison:
                json:     2229.5 i/s
                  oj:     1842.0 i/s - 1.21x  slower


== Encoding canada.json (2090234 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.000 i/100ms
                  oj     1.000 i/100ms
Calculating -------------------------------------
                json     11.450 (± 0.0%) i/s   (87.33 ms/i) -     58.000 in   5.066321s
                  oj     11.135 (± 0.0%) i/s   (89.81 ms/i) -     56.000 in   5.029813s

Comparison:
                json:       11.5 i/s
                  oj:       11.1 i/s - 1.03x  slower


== Encoding many #to_json calls (2701 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     2.434k i/100ms
                  oj     2.105k i/100ms
Calculating -------------------------------------
                json     24.448k (± 0.8%) i/s   (40.90 μs/i) -    124.134k in   5.077829s
                  oj     20.934k (± 0.9%) i/s   (47.77 μs/i) -    105.250k in   5.028205s

Comparison:
                json:    24447.9 i/s
                  oj:    20933.5 i/s - 1.17x  slower

```

