### PR TITLE
Introduce JSON::Fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ You can also use the `pretty_generate` method (which formats the output more
 verbosely and nicely) or `fast_generate` (which doesn't do any of the security
 checks generate performs, e. g. nesting deepness checks).
 
+## Combining JSON fragments
+
+To combine JSON fragments to build a bigger JSON document, you can use `JSON::Fragment`:
+
+```ruby
+posts_json = cache.fetch_multi(post_ids) do |post_id|
+  JSON.generate(Post.find(post_id))
+end
+posts_json.map { |post_json| JSON::Fragment.new(post_json) }
+JSON.generate({ posts: posts_json, count: posts_json.count })
+```
+
 ## Handling arbitrary types
 
 > [!CAUTION]

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -167,6 +167,12 @@ module JSON
   # system. Usually this means that the iconv library is not installed.
   class MissingUnicodeSupport < JSONError; end
 
+  Fragment = Struct.new(:json) do
+    def to_json(state = nil)
+      json
+    end
+  end
+
   module_function
 
   # :call-seq:

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -661,4 +661,9 @@ class JSONGeneratorTest < Test::Unit::TestCase
   def test_nonutf8_encoding
     assert_equal("\"5\u{b0}\"", "5\xb0".dup.force_encoding(Encoding::ISO_8859_1).to_json)
   end
+
+  def test_fragment
+    fragment = JSON::Fragment.new(" 42")
+    assert_equal '{"number": 42}', JSON.generate({ number: fragment })
+  end
 end


### PR DESCRIPTION
To combine JSON fragments to build a bigger JSON document, you can use `JSON::Fragment`:

```ruby
posts_json = cache.fetch_multi(post_ids) do |post_id|
  JSON.generate(Post.find(post_id))
end
posts_json.map { |post_json| JSON::Fragment.new(post_json) }
JSON.generate({ posts: posts_json, count: posts_json.count })
```