### PR TITLE
Fix parsing incomplete unicode escape "\uaaa"

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -630,7 +630,7 @@ static VALUE json_string_unescape(JSON_ParserState *state, const char *string, c
                 unescape = (char *) "\f";
                 break;
             case 'u':
-                if (pe > stringEnd - 4) {
+                if (pe > stringEnd - 5) {
                   raise_parse_error("incomplete unicode character escape sequence at '%s'", p);
                 } else {
                     uint32_t ch = unescape_unicode((unsigned char *) ++pe);

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -302,6 +302,14 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_invalid_unicode_escape
+    assert_raise(JSON::ParserError) { parse('"\u"') }
+    assert_raise(JSON::ParserError) { parse('"\ua"') }
+    assert_raise(JSON::ParserError) { parse('"\uaa"') }
+    assert_raise(JSON::ParserError) { parse('"\uaaa"') }
+    assert_equal "\uaaaa", parse('"\uaaaa"')
+  end
+
   def test_parse_big_integers
     json1 = JSON(orig = (1 << 31) - 1)
     assert_equal orig, parse(json1)


### PR DESCRIPTION
Fix segmentation fault parsing `"\uaaa"`
```ruby
1000.times { JSON.parse '"\\uaaa"' rescue nil }
```