### PR TITLE
Use bit twiddling to speed up JSON generation.

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -249,12 +249,12 @@ static inline void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str, const un
 #define hasless(x,n) (((x)-~0ULL/255*(n))&~(x)&~0ULL/255*128)
 #define haszero(v) (((v) - 0x0101010101010101ULL) & ~(v) & 0x8080808080808080ULL)
 #define MASK_DOUBLEQUOTE  0x2222222222222222ULL
-#define MASK_FORWARDSLASH 0x5c5c5c5c5c5c5c5cULL
+#define MASK_BACKSLASH 0x5c5c5c5c5c5c5c5cULL
 # elif SIZEOF_UINTPTR_T == 4
 #define hasless(x,n) (((x)-~0UL/255*(n))&~(x)&~0UL/255*128)
 #define haszero(v) (((v) - 0x01010101UL) & ~(v) & 0x80808080UL)
 #define MASK_DOUBLEQUOTE  0x22222222UL
-#define MASK_FORWARDSLASH 0x5c5c5c5cUL
+#define MASK_BACKSLASH 0x5c5c5c5cUL
 # else
 #  error "don't know what to do."
 #endif
@@ -288,7 +288,7 @@ static inline void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str, const un
                 uintptr_t tmp1 = chunk ^ MASK_DOUBLEQUOTE;
                 uintptr_t haszero1 = haszero(tmp1);
 
-                uintptr_t tmp2 = chunk ^ MASK_FORWARDSLASH;
+                uintptr_t tmp2 = chunk ^ MASK_BACKSLASH;
                 uintptr_t haszero2 = haszero(tmp2);
 
                 if ((has_less_than_0x20 | haszero1 | haszero2) != 0) {

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -435,6 +435,10 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["/"]'
     assert_equal json, generate(data)
     #
+    data = [ '////////////////////////////////////////////////////////////////////////////////////' ]
+    json = '["////////////////////////////////////////////////////////////////////////////////////"]'
+    assert_equal json, generate(data)
+    #
     data = [ '/' ]
     json = '["\/"]'
     assert_equal json, generate(data, :script_safe => true)
@@ -455,6 +459,14 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["\""]'
     assert_equal json, generate(data)
     #
+    data = [ '///////////' ]
+    json = '["\/\/\/\/\/\/\/\/\/\/\/"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
+    data = [ '///////////////////////////////////////////////////////' ]
+    json = '["\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
     data = ["'"]
     json = '["\\\'"]'
     assert_equal '["\'"]', generate(data)
@@ -462,6 +474,30 @@ class JSONGeneratorTest < Test::Unit::TestCase
     data = ["倩", "瀨"]
     json = '["倩","瀨"]'
     assert_equal json, generate(data, script_safe: true)
+    #
+    data = '["This is a "test" of the emergency broadcast system."]'
+    json = "\"[\\\"This is a \\\"test\\\" of the emergency broadcast system.\\\"]\""
+    assert_equal json, generate(data)
+    #
+    data = '\tThis is a test of the emergency broadcast system.'
+    json = "\"\\\\tThis is a test of the emergency broadcast system.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This\tis a test of the emergency broadcast system.'
+    json = "\"This\\\\tis a test of the emergency broadcast system.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This is\ta test of the emergency broadcast system.'
+    json = "\"This is\\\\ta test of the emergency broadcast system.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This is a test of the emergency broadcast\tsystem.'
+    json = "\"This is a test of the emergency broadcast\\\\tsystem.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This is a test of the emergency broadcast\tsystem.\n'
+    json = "\"This is a test of the emergency broadcast\\\\tsystem.\\\\n\""
+    assert_equal json, generate(data)
   end
 
   def test_string_subclass


### PR DESCRIPTION
Create this as separate from the SIMD branch. 

Use [bit twiddling](https://graphics.stanford.edu/~seander/bithacks.html) to speed up JSON generation. 

This effectively inlines `memchr(ptr, '"', len)` and `memchr(ptr, '\\', len)` as well as a `<each byte in chunk> < 0x20` comparison. 

## Benchmarks

### Macbook Air M1

#### This Branch
```
== Encoding small mixed (34 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   442.754k i/100ms
          json_coder   474.965k i/100ms
                  oj   419.655k i/100ms
Calculating -------------------------------------
                json      4.380M (± 5.3%) i/s  (228.29 ns/i) -     22.138M in   5.071138s
          json_coder      4.721M (± 3.2%) i/s  (211.84 ns/i) -     23.748M in   5.036884s
                  oj      4.223M (± 1.6%) i/s  (236.80 ns/i) -     21.402M in   5.069275s

Comparison:
                json:  4380401.0 i/s
          json_coder:  4720500.3 i/s - same-ish: difference falls within error
                  oj:  4223023.2 i/s - same-ish: difference falls within error


== Encoding small nested array (121 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   214.704k i/100ms
          json_coder   217.984k i/100ms
                  oj   172.417k i/100ms
Calculating -------------------------------------
                json      2.134M (± 2.8%) i/s  (468.71 ns/i) -     10.735M in   5.036328s
          json_coder      2.119M (±12.8%) i/s  (471.89 ns/i) -     10.463M in   5.074812s
                  oj      1.728M (± 0.4%) i/s  (578.56 ns/i) -      8.793M in   5.087548s

Comparison:
                json:  2133536.6 i/s
          json_coder:  2119147.6 i/s - same-ish: difference falls within error
                  oj:  1728423.1 i/s - 1.23x  slower


== Encoding small hash (65 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   448.998k i/100ms
          json_coder   480.577k i/100ms
                  oj   485.067k i/100ms
Calculating -------------------------------------
                json      4.485M (± 0.4%) i/s  (222.96 ns/i) -     22.450M in   5.005564s
          json_coder      4.729M (± 2.0%) i/s  (211.45 ns/i) -     24.029M in   5.082987s
                  oj      4.847M (± 0.5%) i/s  (206.30 ns/i) -     24.253M in   5.003676s

Comparison:
                json:  4485075.4 i/s
                  oj:  4847239.0 i/s - 1.08x  faster
          json_coder:  4729330.3 i/s - 1.05x  faster


== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    60.000 i/100ms
          json_coder    59.000 i/100ms
                  oj    34.000 i/100ms
Calculating -------------------------------------
                json    538.363 (±14.9%) i/s    (1.86 ms/i) -      2.640k in   5.008175s
          json_coder    544.629 (±12.3%) i/s    (1.84 ms/i) -      2.714k in   5.059221s
                  oj    357.057 (± 3.6%) i/s    (2.80 ms/i) -      1.802k in   5.053765s

Comparison:
                json:      538.4 i/s
          json_coder:      544.6 i/s - same-ish: difference falls within error
                  oj:      357.1 i/s - 1.51x  slower


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    53.000 i/100ms
          json_coder    46.000 i/100ms
                  oj    34.000 i/100ms
Calculating -------------------------------------
                json    524.858 (± 7.4%) i/s    (1.91 ms/i) -      2.650k in   5.077503s
          json_coder    543.170 (± 7.0%) i/s    (1.84 ms/i) -      2.714k in   5.020620s
                  oj    351.649 (± 3.7%) i/s    (2.84 ms/i) -      1.768k in   5.034501s

Comparison:
                json:      524.9 i/s
          json_coder:      543.2 i/s - same-ish: difference falls within error
                  oj:      351.6 i/s - 1.49x  slower


== Encoding integers (8009 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     8.123k i/100ms
          json_coder     7.976k i/100ms
                  oj     7.332k i/100ms
Calculating -------------------------------------
                json     80.441k (± 1.1%) i/s   (12.43 μs/i) -    406.150k in   5.049727s
          json_coder     80.854k (± 1.3%) i/s   (12.37 μs/i) -    406.776k in   5.031830s
                  oj     73.209k (± 0.8%) i/s   (13.66 μs/i) -    366.600k in   5.007896s

Comparison:
                json:    80440.5 i/s
          json_coder:    80853.6 i/s - same-ish: difference falls within error
                  oj:    73208.8 i/s - 1.10x  slower


== Encoding activitypub.json (52595 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     2.045k i/100ms
          json_coder     1.999k i/100ms
                  oj     1.582k i/100ms
Calculating -------------------------------------
                json     20.584k (± 5.4%) i/s   (48.58 μs/i) -    104.295k in   5.082094s
          json_coder     21.065k (± 3.3%) i/s   (47.47 μs/i) -    105.947k in   5.035064s
                  oj     15.678k (± 2.5%) i/s   (63.78 μs/i) -     79.100k in   5.048520s

Comparison:
                json:    20584.0 i/s
          json_coder:    21065.5 i/s - same-ish: difference falls within error
                  oj:    15678.2 i/s - 1.31x  slower


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   109.000 i/100ms
          json_coder   109.000 i/100ms
                  oj    92.000 i/100ms
Calculating -------------------------------------
                json      1.108k (± 2.2%) i/s  (902.53 μs/i) -      5.559k in   5.019493s
          json_coder      1.105k (± 2.7%) i/s  (904.61 μs/i) -      5.559k in   5.032499s
                  oj    914.626 (± 1.9%) i/s    (1.09 ms/i) -      4.600k in   5.031155s

Comparison:
                json:     1108.0 i/s
          json_coder:     1105.5 i/s - same-ish: difference falls within error
                  oj:      914.6 i/s - 1.21x  slower


== Encoding twitter.json (466906 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   201.000 i/100ms
          json_coder   210.000 i/100ms
                  oj   188.000 i/100ms
Calculating -------------------------------------
                json      2.117k (± 2.6%) i/s  (472.28 μs/i) -     10.653k in   5.034844s
          json_coder      2.169k (± 3.0%) i/s  (460.95 μs/i) -     10.920k in   5.038295s
                  oj      1.915k (± 2.9%) i/s  (522.32 μs/i) -      9.588k in   5.012425s

Comparison:
                json:     2117.4 i/s
          json_coder:     2169.4 i/s - same-ish: difference falls within error
                  oj:     1914.5 i/s - 1.11x  slower


== Encoding canada.json (2090234 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.000 i/100ms
          json_coder     1.000 i/100ms
                  oj     1.000 i/100ms
Calculating -------------------------------------
                json     10.820 (± 9.2%) i/s   (92.42 ms/i) -     54.000 in   5.017790s
          json_coder     10.958 (± 0.0%) i/s   (91.26 ms/i) -     55.000 in   5.019486s
                  oj     10.684 (± 0.0%) i/s   (93.60 ms/i) -     54.000 in   5.054718s

Comparison:
                json:       10.8 i/s
          json_coder:       11.0 i/s - same-ish: difference falls within error
                  oj:       10.7 i/s - same-ish: difference falls within error


== Encoding many #to_json calls (2701 bytes)
json_coder unsupported (Object not allowed in JSON)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     2.369k i/100ms
                  oj     1.970k i/100ms
Calculating -------------------------------------
                json     22.647k (±11.0%) i/s   (44.16 μs/i) -    111.343k in   5.007278s
                  oj     19.705k (± 0.8%) i/s   (50.75 μs/i) -    100.470k in   5.099096s

Comparison:
                json:    22646.9 i/s
                  oj:    19704.8 i/s - 1.15x  slower
```

#### Master

```
== Encoding small mixed (34 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   408.721k i/100ms
          json_coder   463.041k i/100ms
                  oj   427.971k i/100ms
Calculating -------------------------------------
                json      4.374M (± 1.1%) i/s  (228.63 ns/i) -     22.071M in   5.046598s
          json_coder      4.594M (± 3.9%) i/s  (217.68 ns/i) -     23.152M in   5.048782s
                  oj      4.207M (± 1.8%) i/s  (237.71 ns/i) -     21.399M in   5.088352s

Comparison:
                json:  4373951.5 i/s
          json_coder:  4593891.7 i/s - same-ish: difference falls within error
                  oj:  4206829.7 i/s - 1.04x  slower


== Encoding small nested array (121 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   204.636k i/100ms
          json_coder   208.879k i/100ms
                  oj   164.519k i/100ms
Calculating -------------------------------------
                json      2.025M (± 1.5%) i/s  (493.93 ns/i) -     10.232M in   5.054997s
          json_coder      2.079M (± 1.7%) i/s  (480.97 ns/i) -     10.444M in   5.024722s
                  oj      1.728M (± 1.0%) i/s  (578.84 ns/i) -      8.720M in   5.047656s

Comparison:
                json:  2024578.5 i/s
          json_coder:  2079136.1 i/s - same-ish: difference falls within error
                  oj:  1727606.7 i/s - 1.17x  slower


== Encoding small hash (65 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   449.534k i/100ms
          json_coder   480.253k i/100ms
                  oj   480.245k i/100ms
Calculating -------------------------------------
                json      4.464M (± 0.7%) i/s  (224.02 ns/i) -     22.477M in   5.035527s
          json_coder      4.748M (± 1.2%) i/s  (210.61 ns/i) -     24.013M in   5.058006s
                  oj      4.633M (± 3.5%) i/s  (215.83 ns/i) -     23.532M in   5.085593s

Comparison:
                json:  4463831.3 i/s
          json_coder:  4748140.8 i/s - 1.06x  faster
                  oj:  4633342.9 i/s - same-ish: difference falls within error


== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    34.000 i/100ms
          json_coder    35.000 i/100ms
                  oj    35.000 i/100ms
Calculating -------------------------------------
                json    348.297 (± 8.0%) i/s    (2.87 ms/i) -      1.734k in   5.013098s
          json_coder    362.582 (± 7.4%) i/s    (2.76 ms/i) -      1.820k in   5.049010s
                  oj    352.399 (± 3.7%) i/s    (2.84 ms/i) -      1.785k in   5.072121s

Comparison:
                json:      348.3 i/s
          json_coder:      362.6 i/s - same-ish: difference falls within error
                  oj:      352.4 i/s - same-ish: difference falls within error


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    37.000 i/100ms
          json_coder    34.000 i/100ms
                  oj    35.000 i/100ms
Calculating -------------------------------------
                json    356.095 (± 5.3%) i/s    (2.81 ms/i) -      1.776k in   5.002047s
          json_coder    352.925 (± 6.2%) i/s    (2.83 ms/i) -      1.768k in   5.029325s
                  oj    354.508 (± 3.4%) i/s    (2.82 ms/i) -      1.785k in   5.040838s

Comparison:
                json:      356.1 i/s
                  oj:      354.5 i/s - same-ish: difference falls within error
          json_coder:      352.9 i/s - same-ish: difference falls within error


== Encoding integers (8009 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     7.849k i/100ms
          json_coder     7.886k i/100ms
                  oj     7.325k i/100ms
Calculating -------------------------------------
                json     78.319k (± 1.4%) i/s   (12.77 μs/i) -    392.450k in   5.011962s
          json_coder     78.569k (± 1.1%) i/s   (12.73 μs/i) -    394.300k in   5.019102s
                  oj     72.923k (± 0.8%) i/s   (13.71 μs/i) -    366.250k in   5.022750s

Comparison:
                json:    78319.0 i/s
          json_coder:    78569.2 i/s - same-ish: difference falls within error
                  oj:    72922.6 i/s - 1.07x  slower


== Encoding activitypub.json (52595 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.718k i/100ms
          json_coder     1.748k i/100ms
                  oj     1.545k i/100ms
Calculating -------------------------------------
                json     17.558k (± 3.1%) i/s   (56.95 μs/i) -     89.336k in   5.093146s
          json_coder     17.814k (± 3.3%) i/s   (56.13 μs/i) -     89.148k in   5.009813s
                  oj     15.292k (± 3.6%) i/s   (65.40 μs/i) -     77.250k in   5.058386s

Comparison:
                json:    17558.0 i/s
          json_coder:    17814.3 i/s - same-ish: difference falls within error
                  oj:    15291.5 i/s - 1.15x  slower


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   103.000 i/100ms
          json_coder   107.000 i/100ms
                  oj    88.000 i/100ms
Calculating -------------------------------------
                json      1.023k (±10.7%) i/s  (977.19 μs/i) -      5.047k in   5.046689s
          json_coder      1.068k (± 3.4%) i/s  (936.16 μs/i) -      5.350k in   5.014254s
                  oj    895.747 (± 3.0%) i/s    (1.12 ms/i) -      4.488k in   5.014907s

Comparison:
                json:     1023.3 i/s
          json_coder:     1068.2 i/s - same-ish: difference falls within error
                  oj:      895.7 i/s - same-ish: difference falls within error


== Encoding twitter.json (466906 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   189.000 i/100ms
          json_coder   185.000 i/100ms
                  oj   178.000 i/100ms
Calculating -------------------------------------
                json      1.952k (± 2.9%) i/s  (512.35 μs/i) -      9.828k in   5.039805s
          json_coder      1.975k (± 2.3%) i/s  (506.32 μs/i) -      9.990k in   5.060905s
                  oj      1.929k (± 2.4%) i/s  (518.51 μs/i) -      9.790k in   5.079165s

Comparison:
                json:     1951.8 i/s
          json_coder:     1975.0 i/s - same-ish: difference falls within error
                  oj:     1928.6 i/s - same-ish: difference falls within error


== Encoding canada.json (2090234 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.000 i/100ms
          json_coder     1.000 i/100ms
                  oj     1.000 i/100ms
Calculating -------------------------------------
                json     10.785 (± 0.0%) i/s   (92.72 ms/i) -     55.000 in   5.111775s
          json_coder     10.845 (± 0.0%) i/s   (92.21 ms/i) -     55.000 in   5.072654s
                  oj     10.705 (± 0.0%) i/s   (93.41 ms/i) -     54.000 in   5.044590s

Comparison:
                json:       10.8 i/s
          json_coder:       10.8 i/s - 1.01x  faster
                  oj:       10.7 i/s - 1.01x  slower


== Encoding many #to_json calls (2701 bytes)
json_coder unsupported (Object not allowed in JSON)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     2.356k i/100ms
                  oj     1.967k i/100ms
Calculating -------------------------------------
                json     22.902k (± 7.6%) i/s   (43.66 μs/i) -    115.444k in   5.081692s
                  oj     19.756k (± 1.1%) i/s   (50.62 μs/i) -    100.317k in   5.078382s

Comparison:
                json:    22902.2 i/s
                  oj:    19756.4 i/s - 1.16x  slower
```