### PR TITLE
Avoid plain char for ctype macros

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -135,7 +135,7 @@ static VALUE rstring_cache_fetch(rvalue_cache *cache, const char *str, const lon
         return Qfalse;
     }
 
-    if (RB_UNLIKELY(!isalpha(str[0]))) {
+    if (RB_UNLIKELY(!isalpha((unsigned char)str[0]))) {
         // Simple heuristic, if the first character isn't a letter,
         // we're much less likely to see this string again.
         // We mostly want to cache strings that are likely to be repeated.
@@ -187,7 +187,7 @@ static VALUE rsymbol_cache_fetch(rvalue_cache *cache, const char *str, const lon
         return Qfalse;
     }
 
-    if (RB_UNLIKELY(!isalpha(str[0]))) {
+    if (RB_UNLIKELY(!isalpha((unsigned char)str[0]))) {
         // Simple heuristic, if the first character isn't a letter,
         // we're much less likely to see this string again.
         // We mostly want to cache strings that are likely to be repeated.


### PR DESCRIPTION
On some platforms ctype functions are defined as macros accesing tables. A plain char may be `signed` or `unsigned` per implementations and the extension result implementation dependent.

gcc warns such case:

```
parser.c: In function 'rstring_cache_fetch':
parser.c:138:33: warning: array subscript has type 'char' [-Wchar-subscripts]
  138 |     if (RB_UNLIKELY(!isalpha(str[0]))) {
      |                              ~~~^~~
parser.c: In function 'rsymbol_cache_fetch':
parser.c:190:33: warning: array subscript has type 'char' [-Wchar-subscripts]
  190 |     if (RB_UNLIKELY(!isalpha(str[0]))) {
      |                              ~~~^~~
```