### PR TITLE
Optimize Symbol generation in strict mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Changes
 
+* `strict: true` now accept symbols as values. Previously they'd only be accepted as hash keys.
 * The C extension Parser has been entirely reimplemented from scratch.
 * Introduced `JSON::Coder` as a new API allowing to customize how non native types are serialized in a non-global way.
-
 
 ### 2024-12-18 (2.9.1)
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -991,6 +991,29 @@ static void generate_json_string(FBuffer *buffer, struct generate_json_data *dat
     fbuffer_append_char(buffer, '"');
 }
 
+static void generate_json_fallback(FBuffer *buffer, struct generate_json_data *data, JSON_Generator_State *state, VALUE obj)
+{
+    VALUE tmp;
+    if (rb_respond_to(obj, i_to_json)) {
+        tmp = rb_funcall(obj, i_to_json, 1, vstate_get(data));
+        Check_Type(tmp, T_STRING);
+        fbuffer_append_str(buffer, tmp);
+    } else {
+        tmp = rb_funcall(obj, i_to_s, 0);
+        Check_Type(tmp, T_STRING);
+        generate_json_string(buffer, data, state, tmp);
+    }
+}
+
+static inline void generate_json_symbol(FBuffer *buffer, struct generate_json_data *data, JSON_Generator_State *state, VALUE obj)
+{
+    if (state->strict) {
+        generate_json_string(buffer, data, state, rb_sym2str(obj));
+    } else {
+        generate_json_fallback(buffer, data, state, obj);
+    }
+}
+
 static void generate_json_null(FBuffer *buffer, struct generate_json_data *data, JSON_Generator_State *state, VALUE obj)
 {
     fbuffer_append(buffer, "null", 4);
@@ -1049,7 +1072,6 @@ static void generate_json_fragment(FBuffer *buffer, struct generate_json_data *d
 
 static void generate_json(FBuffer *buffer, struct generate_json_data *data, JSON_Generator_State *state, VALUE obj)
 {
-    VALUE tmp;
     bool as_json_called = false;
 start:
     if (obj == Qnil) {
@@ -1063,6 +1085,8 @@ start:
             generate_json_fixnum(buffer, data, state, obj);
         } else if (RB_FLONUM_P(obj)) {
             generate_json_float(buffer, data, state, obj);
+        } else if (RB_STATIC_SYM_P(obj)) {
+            generate_json_symbol(buffer, data, state, obj);
         } else {
             goto general;
         }
@@ -1084,6 +1108,9 @@ start:
                 if (klass != rb_cString) goto general;
                 generate_json_string(buffer, data, state, obj);
                 break;
+            case T_SYMBOL:
+                generate_json_symbol(buffer, data, state, obj);
+                break;
             case T_FLOAT:
                 if (klass != rb_cFloat) goto general;
                 generate_json_float(buffer, data, state, obj);
@@ -1102,14 +1129,8 @@ start:
                     } else {
                         raise_generator_error(obj, "%"PRIsVALUE" not allowed in JSON", CLASS_OF(obj));
                     }
-                } else if (rb_respond_to(obj, i_to_json)) {
-                    tmp = rb_funcall(obj, i_to_json, 1, vstate_get(data));
-                    Check_Type(tmp, T_STRING);
-                    fbuffer_append_str(buffer, tmp);
                 } else {
-                    tmp = rb_funcall(obj, i_to_s, 0);
-                    Check_Type(tmp, T_STRING);
-                    generate_json_string(buffer, data, state, tmp);
+                    generate_json_fallback(buffer, data, state, obj);
                 }
         }
     }

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -108,6 +108,8 @@ public final class Generator {
             case FLOAT  : return (Handler<T>) FLOAT_HANDLER;
             case FIXNUM : return (Handler<T>) FIXNUM_HANDLER;
             case BIGNUM : return (Handler<T>) BIGNUM_HANDLER;
+            case SYMBOL :
+                return (Handler<T>) SYMBOL_HANDLER;
             case STRING :
                 if (Helpers.metaclass(object) != runtime.getString()) break;
                 return (Handler<T>) STRING_HANDLER;
@@ -454,6 +456,29 @@ public final class Generator {
                         break;
                     default:
                         throw Utils.buildGeneratorError(context, object, "source sequence is illegal/malformed utf-8").toThrowable();
+                }
+            }
+        };
+
+    static final Handler<RubySymbol> SYMBOL_HANDLER =
+        new Handler<RubySymbol>() {
+            @Override
+            int guessSize(ThreadContext context, Session session, RubySymbol object) {
+                GeneratorState state = session.getState(context);
+                if (state.strict()) {
+                    return STRING_HANDLER.guessSize(context, session, object.asString());
+                } else {
+                    return GENERIC_HANDLER.guessSize(context, session, object);
+                }
+            }
+
+            @Override
+            void generate(ThreadContext context, Session session, RubySymbol object, OutputStream buffer) throws IOException {
+                GeneratorState state = session.getState(context);
+                if (state.strict()) {
+                    STRING_HANDLER.generate(context, session, object.asString(), buffer);
+                } else {
+                    GENERIC_HANDLER.generate(context, session, object, buffer);
                 }
             }
         };

--- a/lib/json/add/symbol.rb
+++ b/lib/json/add/symbol.rb
@@ -36,8 +36,13 @@ class Symbol
   #
   #   # {"json_class":"Symbol","s":"foo"}
   #
-  def to_json(*a)
-    as_json.to_json(*a)
+  def to_json(state = nil, *a)
+    state = ::JSON::State.from_state(state)
+    if state.strict?
+      super
+    else
+      as_json.to_json(state, *a)
+    end
   end
 
   # See #as_json.

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -86,6 +86,10 @@ class JSONGeneratorTest < Test::Unit::TestCase
 
     assert_equal '42', dump(42, strict: true)
     assert_equal 'true', dump(true, strict: true)
+
+    assert_equal '"hello"', dump(:hello, strict: true)
+    assert_equal '"hello"', :hello.to_json(strict: true)
+    assert_equal '"World"', "World".to_json(strict: true)
   end
 
   def test_generate_pretty


### PR DESCRIPTION
In strict mode we don't need to check for `to_json`, we can just generate a String from a Symbol.

It changes behavior because previously Symbol caused a generator error. But keys in hashes already had support for automatic coercion to String, so it feels ok to do.