### PR TITLE
Fix a compatibility issue with `MultiJson.dump(obj, pretty: true)`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Fix a compatibility issue with `MultiJson.dump(obj, pretty: true)`: `no implicit conversion of false into Proc (TypeError)`.
+
 ### 2025-02-10 (2.10.0)
 
 * `strict: true` now accept symbols as values. Previously they'd only be accepted as hash keys.

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1626,7 +1626,7 @@ static int configure_state_i(VALUE key, VALUE val, VALUE _arg)
     else if (key == sym_script_safe)           { state->script_safe = RTEST(val); }
     else if (key == sym_escape_slash)          { state->script_safe = RTEST(val); }
     else if (key == sym_strict)                { state->strict = RTEST(val); }
-    else if (key == sym_as_json)               { state->as_json = rb_convert_type(val, T_DATA, "Proc", "to_proc"); }
+    else if (key == sym_as_json)               { state->as_json = RTEST(val) ? rb_convert_type(val, T_DATA, "Proc", "to_proc") : Qfalse; }
     return ST_CONTINUE;
 }
 

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -368,9 +368,12 @@ public class GeneratorState extends RubyObject {
     }
 
     @JRubyMethod(name="as_json=")
-    public IRubyObject as_json_set(ThreadContext context,
-                                   IRubyObject asJSON) {
-        this.asJSON = (RubyProc)TypeConverter.convertToType(asJSON, context.getRuntime().getProc(), "to_proc");
+    public IRubyObject as_json_set(ThreadContext context, IRubyObject asJSON) {
+        if (asJSON.isNil() || asJSON == context.getRuntime().getFalse()) {
+            this.asJSON = null;
+        } else {
+            this.asJSON = (RubyProc)TypeConverter.convertToType(asJSON, context.getRuntime().getProc(), "to_proc");
+        }
         return asJSON;
     }
 

--- a/java/src/json/ext/OptionsReader.java
+++ b/java/src/json/ext/OptionsReader.java
@@ -115,7 +115,7 @@ final class OptionsReader {
 
     RubyProc getProc(String key) {
         IRubyObject value = get(key);
-        if (value == null) return null;
+        if (value == null || value.isNil() || value == runtime.getFalse()) return null;
         return (RubyProc)TypeConverter.convertToType(value, runtime.getProc(), "to_proc");
     }
 }

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -258,7 +258,7 @@ module JSON
           @object_nl             = opts[:object_nl]     || '' if opts.key?(:object_nl)
           @array_nl              = opts[:array_nl]      || '' if opts.key?(:array_nl)
           @allow_nan             = !!opts[:allow_nan]         if opts.key?(:allow_nan)
-          @as_json               = opts[:as_json].to_proc     if opts.key?(:as_json)
+          @as_json               = opts[:as_json].to_proc     if opts[:as_json]
           @ascii_only            = opts[:ascii_only]          if opts.key?(:ascii_only)
           @depth                 = opts[:depth] || 0
           @buffer_initial_length ||= opts[:buffer_initial_length]

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -399,6 +399,11 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_equal :bar, state_hash[:foo]
   end
 
+  def test_json_state_to_h_roundtrip
+    state = JSON.state.new
+    assert_equal state.to_h, JSON.state.new(state.to_h).to_h
+  end
+
   def test_json_generate
     assert_raise JSON::GeneratorError do
       generate(["\xea"])


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/748

`MultiJson` pass `State#to_h` as options, and the `as_json` property defaults to `false` but `false` wasn't accepted by the constructor.