### PR TITLE
Fix JSON::GeneratorError#detailed_message with Ruby < 3.2

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -152,10 +152,13 @@ module JSON
     end
 
     def detailed_message(...)
+      # Exception#detailed_message doesn't exist until Ruby 3.2
+      super_message = defined?(super) ? super : message
+
       if @invalid_object.nil?
-        super
+        super_message
       else
-        "#{super}\nInvalid object: #{@invalid_object.inspect}"
+        "#{super_message}\nInvalid object: #{@invalid_object.inspect}"
       end
     end
   end

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -410,6 +410,14 @@ class JSONGeneratorTest < Test::Unit::TestCase
     end
   end
 
+  def test_json_generate_error_detailed_message
+    error = assert_raise JSON::GeneratorError do
+      generate(["\xea"])
+    end
+
+    assert_not_nil(error.detailed_message)
+  end
+
   def test_json_generate_unsupported_types
     assert_raise JSON::GeneratorError do
       generate(Object.new, strict: true)


### PR DESCRIPTION
Fixes #758 

`Exception#detailed_message` didn't exist until Ruby 3.2. https://bugs.ruby-lang.org/journals/96316/diff?detail_id=61977

https://github.com/ruby/json/pull/712 added `JSON::GeneratorError` which defines `#detailed_message` expecting to delegate to `super`. For affected rubies this leads to `NoMethodError` if invoked, eg as happens [here in sinatra](https://github.com/sinatra/sinatra/blob/c235249abaafa2780b540aca1813dfcf3d17c2dd/lib/sinatra/base.rb#L1272-L1273).
