### PR TITLE
Raise a ParserError on all incomplete unicode escape sequence.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Changes
 
+* Raise a ParserError on all incomplete unicode escape sequence. This was the behavior until `2.10.0` unadvertently changed it.
 * Ensure document snippets that are included in parser errors don't include truncated multibyte characters.
 
 ### 2025-02-10 (2.10.1)

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -311,6 +311,11 @@ class JSONParserTest < Test::Unit::TestCase
     assert_raise(JSON::ParserError) { parse('"\uaa"') }
     assert_raise(JSON::ParserError) { parse('"\uaaa"') }
     assert_equal "\uaaaa", parse('"\uaaaa"')
+
+    assert_raise(JSON::ParserError) { parse('"\u______"') }
+    assert_raise(JSON::ParserError) { parse('"\u1_____"') }
+    assert_raise(JSON::ParserError) { parse('"\u11____"') }
+    assert_raise(JSON::ParserError) { parse('"\u111___"') }
   end
 
   def test_parse_big_integers


### PR DESCRIPTION
This was the behavior until `2.10.0` unadvertently changed it.

`"\u1"` would raise, but `"\u1zzz"` wouldn't.