### PR TITLE
Escape HTML Entities

### DIFF
--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -66,6 +66,7 @@ module JSON
             strict: strict?,
             depth: depth,
             buffer_initial_length: buffer_initial_length,
+            escape_html_entities: escape_html_entities?,
           }
 
           instance_variables.each do |iv|


### PR DESCRIPTION
I'm trying to replace `Oj` with `JSON`, but hit a snag, which leads to this PR.

`Oj.dump(value, mode: :rails)` will perform the equivalent substitutions as `ERB::Util.json_escape`. It escapes more than `JSON.generate(value, script_safe: true)` performs, specifically: 
- `&`
- `>`
- `<`

It does not escape the forward-slash character (`/`), which is escaped by `script_safe`. However, conveniently, we perform a `gsub` on top of that to escape it.

This PR adds a `escape_html_entities` (please bikeshed the name), which is a the union of escaped characters of `script_safe` and `Oj.dump(mode: :rails)`.

I shouldn't be trusted to write production C code so please review carefully.