### PR TITLE
Restore test_parse_malformated_unicode_escapes

### DIFF
--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -673,6 +673,13 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_malformated_unicode_escapes
+    assert_equal "�|", JSON.parse('"\\u1gef|"')
+    assert_equal "�|", JSON.parse('"\\u12ge|"')
+    assert_equal "�|", JSON.parse('"\\u123g|"')
+    assert_equal '�\\\\"', JSON.parse('"\\u1\\\\\\\\\\\\\\\\"')
+  end
+
   private
 
   def string_deduplication_available?


### PR DESCRIPTION
I'm not sure why the current master didn't contain `test_parse_malformated_unicode_escapes` from https://github.com/ruby/json/commit/cf242d89a0523bacd5238a59c77b33411b8c3208.