### PR TITLE
Faster integer formatting

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -3,6 +3,7 @@
 
 #include "ruby.h"
 #include "ruby/encoding.h"
+#include "../vendor/jeaiii-ltoa.h"
 
 /* shims */
 /* This is the fallback definition from Ruby 3.4 */
@@ -150,6 +151,13 @@ static void fbuffer_append(FBuffer *fb, const char *newstr, unsigned long len)
     }
 }
 
+/* Appends a character into a buffer. The buffer needs to have sufficient capacity, via fbuffer_inc_capa(...). */
+static inline void fbuffer_append_reserved_char(FBuffer *fb, char chr)
+{
+    fb->ptr[fb->len] = chr;
+    fb->len += 1;
+}
+
 static void fbuffer_append_str(FBuffer *fb, VALUE str)
 {
     const char *newstr = StringValuePtr(str);
@@ -167,25 +175,39 @@ static inline void fbuffer_append_char(FBuffer *fb, char newchr)
     fb->len++;
 }
 
-static long fltoa(long number, char *buf)
-{
-    static const char digits[] = "0123456789";
-    long sign = number;
-    char* tmp = buf;
-
-    if (sign < 0) number = -number;
-    do *tmp-- = digits[number % 10]; while (number /= 10);
-    if (sign < 0) *tmp-- = '-';
-    return buf - tmp;
-}
-
-#define LONG_BUFFER_SIZE 20
+/*
+ * Appends the decimal string representation of \a number into the buffer.
+ */
 static void fbuffer_append_long(FBuffer *fb, long number)
 {
-    char buf[LONG_BUFFER_SIZE];
-    char *buffer_end = buf + LONG_BUFFER_SIZE;
-    long len = fltoa(number, buffer_end - 1);
-    fbuffer_append(fb, buffer_end - len, len);
+    /*
+     * The to_text_from_ulong() function produces digits left-to-right,
+     * allowing us to write directly into the buffer, but we don't know
+     * the number of resulting characters.
+     *
+     * We do know, however, that the `number` argument is always in the
+     * range 0xc000000000000000 to 0x3fffffffffffffff, or, in decimal, 
+     * -4611686018427387904 to 4611686018427387903. The max number of chars
+     * generated is therefore 20 (including a potential sign character).
+     */
+
+    static const int MAX_CHARS_FOR_LONG = 20;
+
+    fbuffer_inc_capa(fb, MAX_CHARS_FOR_LONG);
+
+    if (number < 0) {
+        fbuffer_append_reserved_char(fb, '-');
+
+        /* 
+         * Since number is always > LONG_MIN, `-number` will not overflow
+         * and is always the positive abs() value.
+         */
+        number = -number;
+    }
+
+    char* d = fb->ptr + fb->len;
+    char* end = to_text_from_ulong(d, number);
+    fb->len += end - d;
 }
 
 static VALUE fbuffer_finalize(FBuffer *fb)

--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -175,13 +175,23 @@ static inline void fbuffer_append_char(FBuffer *fb, char newchr)
     fb->len++;
 }
 
+static inline char *fbuffer_cursor(FBuffer *fb)
+{
+    return fb->ptr + fb->len;
+}
+
+static inline void fbuffer_advance_to(FBuffer *fb, char *end)
+{
+    fb->len = end - fb->ptr;
+}
+
 /*
  * Appends the decimal string representation of \a number into the buffer.
  */
 static void fbuffer_append_long(FBuffer *fb, long number)
 {
     /*
-     * The to_text_from_ulong() function produces digits left-to-right,
+     * The jeaiii_ultoa() function produces digits left-to-right,
      * allowing us to write directly into the buffer, but we don't know
      * the number of resulting characters.
      *
@@ -205,9 +215,8 @@ static void fbuffer_append_long(FBuffer *fb, long number)
         number = -number;
     }
 
-    char* d = fb->ptr + fb->len;
-    char* end = to_text_from_ulong(d, number);
-    fb->len += end - d;
+    char *end = jeaiii_ultoa(fbuffer_cursor(fb), number);
+    fbuffer_advance_to(fb, end);
 }
 
 static VALUE fbuffer_finalize(FBuffer *fb)

--- a/ext/json/ext/generator/depend
+++ b/ext/json/ext/generator/depend
@@ -1,2 +1,3 @@
 generator.o: generator.c $(srcdir)/../fbuffer/fbuffer.h
 generator.o: generator.c $(srcdir)/../vendor/fpconv.c
+generator.o: generator.c $(srcdir)/../vendor/jeaiii-ltoa.h

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1710,6 +1710,7 @@ void Init_generator(void)
     cFragment = rb_const_get(mJSON, rb_intern("Fragment"));
 
     VALUE mExt = rb_define_module_under(mJSON, "Ext");
+
     VALUE mGenerator = rb_define_module_under(mExt, "Generator");
 
     rb_global_variable(&eGeneratorError);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1710,7 +1710,6 @@ void Init_generator(void)
     cFragment = rb_const_get(mJSON, rb_intern("Fragment"));
 
     VALUE mExt = rb_define_module_under(mJSON, "Ext");
-
     VALUE mGenerator = rb_define_module_under(mExt, "Generator");
 
     rb_global_variable(&eGeneratorError);

--- a/ext/json/ext/vendor/jeaiii-ltoa.h
+++ b/ext/json/ext/vendor/jeaiii-ltoa.h
@@ -1,0 +1,257 @@
+/*
+
+This file is released under the terms of the MIT License. It is based on the
+work of James Edward Anhalt III, with the original license listed below.
+
+MIT License
+
+Copyright (c) 2024,2025 Enrico Thierbach - https://github.com/radiospiel
+Copyright (c) 2022 James Edward Anhalt III - https://github.com/jeaiii/itoa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef JEAIII_TO_TEXT_H_
+#define JEAIII_TO_TEXT_H_
+
+#include <stdint.h>
+
+typedef uint_fast32_t u32_t;
+typedef uint_fast64_t u64_t;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+
+#define u32(x) ((u32_t)(x))
+#define u64(x) ((u64_t)(x))
+
+struct pair
+{
+    char dd[2];
+};
+
+#define cast_to_pair_ptr(b) ((struct pair*)(void*)(b))
+
+static struct pair digits_dd[100] =
+{
+    { '0', '0' }, { '0', '1' }, { '0', '2' }, { '0', '3' }, { '0', '4' }, { '0', '5' }, { '0', '6' }, { '0', '7' }, { '0', '8' }, { '0', '9' },
+    { '1', '0' }, { '1', '1' }, { '1', '2' }, { '1', '3' }, { '1', '4' }, { '1', '5' }, { '1', '6' }, { '1', '7' }, { '1', '8' }, { '1', '9' },
+    { '2', '0' }, { '2', '1' }, { '2', '2' }, { '2', '3' }, { '2', '4' }, { '2', '5' }, { '2', '6' }, { '2', '7' }, { '2', '8' }, { '2', '9' },
+    { '3', '0' }, { '3', '1' }, { '3', '2' }, { '3', '3' }, { '3', '4' }, { '3', '5' }, { '3', '6' }, { '3', '7' }, { '3', '8' }, { '3', '9' },
+    { '4', '0' }, { '4', '1' }, { '4', '2' }, { '4', '3' }, { '4', '4' }, { '4', '5' }, { '4', '6' }, { '4', '7' }, { '4', '8' }, { '4', '9' },
+    { '5', '0' }, { '5', '1' }, { '5', '2' }, { '5', '3' }, { '5', '4' }, { '5', '5' }, { '5', '6' }, { '5', '7' }, { '5', '8' }, { '5', '9' },
+    { '6', '0' }, { '6', '1' }, { '6', '2' }, { '6', '3' }, { '6', '4' }, { '6', '5' }, { '6', '6' }, { '6', '7' }, { '6', '8' }, { '6', '9' },
+    { '7', '0' }, { '7', '1' }, { '7', '2' }, { '7', '3' }, { '7', '4' }, { '7', '5' }, { '7', '6' }, { '7', '7' }, { '7', '8' }, { '7', '9' },
+    { '8', '0' }, { '8', '1' }, { '8', '2' }, { '8', '3' }, { '8', '4' }, { '8', '5' }, { '8', '6' }, { '8', '7' }, { '8', '8' }, { '8', '9' },
+    { '9', '0' }, { '9', '1' }, { '9', '2' }, { '9', '3' }, { '9', '4' }, { '9', '5' }, { '9', '6' }, { '9', '7' }, { '9', '8' }, { '9', '9' },
+};
+
+#define NUL 'x'
+
+static struct pair digits_fd[100] =
+{
+    { '0', NUL }, { '1', NUL }, { '2', NUL }, { '3', NUL }, { '4', NUL }, { '5', NUL }, { '6', NUL }, { '7', NUL }, { '8', NUL }, { '9', NUL },
+    { '1', '0' }, { '1', '1' }, { '1', '2' }, { '1', '3' }, { '1', '4' }, { '1', '5' }, { '1', '6' }, { '1', '7' }, { '1', '8' }, { '1', '9' },
+    { '2', '0' }, { '2', '1' }, { '2', '2' }, { '2', '3' }, { '2', '4' }, { '2', '5' }, { '2', '6' }, { '2', '7' }, { '2', '8' }, { '2', '9' },
+    { '3', '0' }, { '3', '1' }, { '3', '2' }, { '3', '3' }, { '3', '4' }, { '3', '5' }, { '3', '6' }, { '3', '7' }, { '3', '8' }, { '3', '9' },
+    { '4', '0' }, { '4', '1' }, { '4', '2' }, { '4', '3' }, { '4', '4' }, { '4', '5' }, { '4', '6' }, { '4', '7' }, { '4', '8' }, { '4', '9' },
+    { '5', '0' }, { '5', '1' }, { '5', '2' }, { '5', '3' }, { '5', '4' }, { '5', '5' }, { '5', '6' }, { '5', '7' }, { '5', '8' }, { '5', '9' },
+    { '6', '0' }, { '6', '1' }, { '6', '2' }, { '6', '3' }, { '6', '4' }, { '6', '5' }, { '6', '6' }, { '6', '7' }, { '6', '8' }, { '6', '9' },
+    { '7', '0' }, { '7', '1' }, { '7', '2' }, { '7', '3' }, { '7', '4' }, { '7', '5' }, { '7', '6' }, { '7', '7' }, { '7', '8' }, { '7', '9' },
+    { '8', '0' }, { '8', '1' }, { '8', '2' }, { '8', '3' }, { '8', '4' }, { '8', '5' }, { '8', '6' }, { '8', '7' }, { '8', '8' }, { '8', '9' },
+    { '9', '0' }, { '9', '1' }, { '9', '2' }, { '9', '3' }, { '9', '4' }, { '9', '5' }, { '9', '6' }, { '9', '7' }, { '9', '8' }, { '9', '9' },
+};
+
+#undef NUL
+
+static u64_t mask24 = (u64(1) << 24) - 1;
+static u64_t mask32 = (u64(1) << 32) - 1;
+static u64_t mask57 = (u64(1) << 57) - 1;
+
+static 
+char* to_text_from_ulong(char* b, u64_t n) {
+    if (n < u32(1e2))
+    {
+        *cast_to_pair_ptr(b) = digits_fd[n];
+        return n < 10 ? b + 1 : b + 2;
+    }
+    if (n < u32(1e6))
+    {
+        if (n < u32(1e4))
+        {
+            u32_t f0 = u32(10 * (1 << 24) / 1e3 + 1) * n;
+            *cast_to_pair_ptr(b) = digits_fd[f0 >> 24];
+            b -= n < u32(1e3);
+            u32_t f2 = (f0 & mask24) * 100;
+            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 24];
+            return b + 4;
+        }
+        u64_t f0 = u64(10 * (1ull << 32ull)/ 1e5 + 1) * n;
+        *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+        b -= n < u32(1e5);
+        u64_t f2 = (f0 & mask32) * 100;
+        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+        u64_t f4 = (f2 & mask32) * 100;
+        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+        return b + 6;
+    }
+    if (n < u64(1ull << 32ull))
+    {
+        if (n < u32(1e8))
+        {
+            u64_t f0 = u64(10 * (1ull << 48ull) / 1e7 + 1) * n >> 16;
+            *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+            b -= n < u32(1e7);
+            u64_t f2 = (f0 & mask32) * 100;
+            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+            u64_t f4 = (f2 & mask32) * 100;
+            *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+            u64_t f6 = (f4 & mask32) * 100;
+            *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+            return b + 8;
+        }
+        u64_t f0 = u64(10 * (1ull << 57ull) / 1e9 + 1) * n;
+        *cast_to_pair_ptr(b) = digits_fd[f0 >> 57];
+        b -= n < u32(1e9);
+        u64_t f2 = (f0 & mask57) * 100;
+        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 57];
+        u64_t f4 = (f2 & mask57) * 100;
+        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 57];
+        u64_t f6 = (f4 & mask57) * 100;
+        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 57];
+        u64_t f8 = (f6 & mask57) * 100;
+        *cast_to_pair_ptr(b + 8) = digits_dd[f8 >> 57];
+        return b + 10;
+    }
+
+    // if we get here U must be u64 but some compilers don't know that, so reassign n to a u64 to avoid warnings
+    u32_t z = n % u32(1e8);
+    u64_t u = n / u32(1e8);
+
+    if (u < u32(1e2))
+    {
+        // u can't be 1 digit (if u < 10 it would have been handled above as a 9 digit 32bit number)
+        *cast_to_pair_ptr(b) = digits_dd[u];
+        b += 2;
+    }
+    else if (u < u32(1e6))
+    {
+        if (u < u32(1e4))
+        {
+            u32_t f0 = u32(10 * (1 << 24) / 1e3 + 1) * u;
+            *cast_to_pair_ptr(b) = digits_fd[f0 >> 24];
+            b -= u < u32(1e3);
+            u32_t f2 = (f0 & mask24) * 100;
+            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 24];
+            b += 4;
+        }
+        else
+        {
+            u64_t f0 = u64(10 * (1ull << 32ull) / 1e5 + 1) * u;
+            *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+            b -= u < u32(1e5);
+            u64_t f2 = (f0 & mask32) * 100;
+            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+            u64_t f4 = (f2 & mask32) * 100;
+            *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+            b += 6;
+        }
+    }
+    else if (u < u32(1e8))
+    {
+        u64_t f0 = u64(10 * (1ull << 48ull) / 1e7 + 1) * u >> 16;
+        *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+        b -= u < u32(1e7);
+        u64_t f2 = (f0 & mask32) * 100;
+        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+        u64_t f4 = (f2 & mask32) * 100;
+        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+        u64_t f6 = (f4 & mask32) * 100;
+        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+        b += 8;
+    }
+    else if (u < u64(1ull << 32ull))
+    {
+        u64_t f0 = u64(10 * (1ull << 57ull) / 1e9 + 1) * u;
+        *cast_to_pair_ptr(b) = digits_fd[f0 >> 57];
+        b -= u < u32(1e9);
+        u64_t f2 = (f0 & mask57) * 100;
+        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 57];
+        u64_t f4 = (f2 & mask57) * 100;
+        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 57];
+        u64_t f6 = (f4 & mask57) * 100;
+        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 57];
+        u64_t f8 = (f6 & mask57) * 100;
+        *cast_to_pair_ptr(b + 8) = digits_dd[f8 >> 57];
+        b += 10;
+    }
+    else
+    {
+        u32_t y = u % u32(1e8);
+        u /= u32(1e8);
+
+        // u is 2, 3, or 4 digits (if u < 10 it would have been handled above)
+        if (u < u32(1e2))
+        {
+            *cast_to_pair_ptr(b) = digits_dd[u];
+            b += 2;
+        }
+        else
+        {
+            u32_t f0 = u32(10 * (1 << 24) / 1e3 + 1) * u;
+            *cast_to_pair_ptr(b) = digits_fd[f0 >> 24];
+            b -= u < u32(1e3);
+            u32_t f2 = (f0 & mask24) * 100;
+            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 24];
+            b += 4;
+        }
+        // do 8 digits
+        u64_t f0 = (u64((1ull << 48ull) / 1e6 + 1) * y >> 16) + 1;
+        *cast_to_pair_ptr(b) = digits_dd[f0 >> 32];
+        u64_t f2 = (f0 & mask32) * 100;
+        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+        u64_t f4 = (f2 & mask32) * 100;
+        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+        u64_t f6 = (f4 & mask32) * 100;
+        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+        b += 8;
+    }
+    // do 8 digits
+    u64_t f0 = (u64((1ull << 48ull) / 1e6 + 1) * z >> 16) + 1;
+    *cast_to_pair_ptr(b) = digits_dd[f0 >> 32];
+    u64_t f2 = (f0 & mask32) * 100;
+    *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+    u64_t f4 = (f2 & mask32) * 100;
+    *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+    u64_t f6 = (f4 & mask32) * 100;
+    *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+    return b + 8;
+}
+
+#undef u32
+#undef u64
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
+
+#endif // JEAIII_TO_TEXT_H_
+

--- a/ext/json/ext/vendor/jeaiii-ltoa.h
+++ b/ext/json/ext/vendor/jeaiii-ltoa.h
@@ -44,102 +44,109 @@ typedef uint_fast64_t u64_t;
 #define u32(x) ((u32_t)(x))
 #define u64(x) ((u64_t)(x))
 
-struct pair
+struct digit_pair
 {
     char dd[2];
 };
 
-#define cast_to_pair_ptr(b) ((struct pair*)(void*)(b))
+static const struct digit_pair *digits_dd = (struct digit_pair *)(
+    "00" "01" "02" "03" "04" "05" "06" "07" "08" "09"
+    "10" "11" "12" "13" "14" "15" "16" "17" "18" "19"
+    "20" "21" "22" "23" "24" "25" "26" "27" "28" "29"
+    "30" "31" "32" "33" "34" "35" "36" "37" "38" "39"
+    "40" "41" "42" "43" "44" "45" "46" "47" "48" "49"
+    "50" "51" "52" "53" "54" "55" "56" "57" "58" "59"
+    "60" "61" "62" "63" "64" "65" "66" "67" "68" "69"
+    "70" "71" "72" "73" "74" "75" "76" "77" "78" "79"
+    "80" "81" "82" "83" "84" "85" "86" "87" "88" "89"
+    "90" "91" "92" "93" "94" "95" "96" "97" "98" "99"
+);
 
-static struct pair digits_dd[100] =
+static const struct digit_pair *digits_fd = (struct digit_pair *)(
+    "0_" "1_" "2_" "3_" "4_" "5_" "6_" "7_" "8_" "9_"
+    "10" "11" "12" "13" "14" "15" "16" "17" "18" "19"
+    "20" "21" "22" "23" "24" "25" "26" "27" "28" "29"
+    "30" "31" "32" "33" "34" "35" "36" "37" "38" "39"
+    "40" "41" "42" "43" "44" "45" "46" "47" "48" "49"
+    "50" "51" "52" "53" "54" "55" "56" "57" "58" "59"
+    "60" "61" "62" "63" "64" "65" "66" "67" "68" "69"
+    "70" "71" "72" "73" "74" "75" "76" "77" "78" "79"
+    "80" "81" "82" "83" "84" "85" "86" "87" "88" "89"
+    "90" "91" "92" "93" "94" "95" "96" "97" "98" "99"
+);
+
+static const u64_t mask24 = (u64(1) << 24) - 1;
+static const u64_t mask32 = (u64(1) << 32) - 1;
+static const u64_t mask57 = (u64(1) << 57) - 1;
+
+#define COPY(buffer, digits) memcpy(buffer, &(digits), sizeof(struct digit_pair))
+
+static char *
+jeaiii_ultoa(char *b, u64_t n)
 {
-    { '0', '0' }, { '0', '1' }, { '0', '2' }, { '0', '3' }, { '0', '4' }, { '0', '5' }, { '0', '6' }, { '0', '7' }, { '0', '8' }, { '0', '9' },
-    { '1', '0' }, { '1', '1' }, { '1', '2' }, { '1', '3' }, { '1', '4' }, { '1', '5' }, { '1', '6' }, { '1', '7' }, { '1', '8' }, { '1', '9' },
-    { '2', '0' }, { '2', '1' }, { '2', '2' }, { '2', '3' }, { '2', '4' }, { '2', '5' }, { '2', '6' }, { '2', '7' }, { '2', '8' }, { '2', '9' },
-    { '3', '0' }, { '3', '1' }, { '3', '2' }, { '3', '3' }, { '3', '4' }, { '3', '5' }, { '3', '6' }, { '3', '7' }, { '3', '8' }, { '3', '9' },
-    { '4', '0' }, { '4', '1' }, { '4', '2' }, { '4', '3' }, { '4', '4' }, { '4', '5' }, { '4', '6' }, { '4', '7' }, { '4', '8' }, { '4', '9' },
-    { '5', '0' }, { '5', '1' }, { '5', '2' }, { '5', '3' }, { '5', '4' }, { '5', '5' }, { '5', '6' }, { '5', '7' }, { '5', '8' }, { '5', '9' },
-    { '6', '0' }, { '6', '1' }, { '6', '2' }, { '6', '3' }, { '6', '4' }, { '6', '5' }, { '6', '6' }, { '6', '7' }, { '6', '8' }, { '6', '9' },
-    { '7', '0' }, { '7', '1' }, { '7', '2' }, { '7', '3' }, { '7', '4' }, { '7', '5' }, { '7', '6' }, { '7', '7' }, { '7', '8' }, { '7', '9' },
-    { '8', '0' }, { '8', '1' }, { '8', '2' }, { '8', '3' }, { '8', '4' }, { '8', '5' }, { '8', '6' }, { '8', '7' }, { '8', '8' }, { '8', '9' },
-    { '9', '0' }, { '9', '1' }, { '9', '2' }, { '9', '3' }, { '9', '4' }, { '9', '5' }, { '9', '6' }, { '9', '7' }, { '9', '8' }, { '9', '9' },
-};
-
-#define NUL 'x'
-
-static struct pair digits_fd[100] =
-{
-    { '0', NUL }, { '1', NUL }, { '2', NUL }, { '3', NUL }, { '4', NUL }, { '5', NUL }, { '6', NUL }, { '7', NUL }, { '8', NUL }, { '9', NUL },
-    { '1', '0' }, { '1', '1' }, { '1', '2' }, { '1', '3' }, { '1', '4' }, { '1', '5' }, { '1', '6' }, { '1', '7' }, { '1', '8' }, { '1', '9' },
-    { '2', '0' }, { '2', '1' }, { '2', '2' }, { '2', '3' }, { '2', '4' }, { '2', '5' }, { '2', '6' }, { '2', '7' }, { '2', '8' }, { '2', '9' },
-    { '3', '0' }, { '3', '1' }, { '3', '2' }, { '3', '3' }, { '3', '4' }, { '3', '5' }, { '3', '6' }, { '3', '7' }, { '3', '8' }, { '3', '9' },
-    { '4', '0' }, { '4', '1' }, { '4', '2' }, { '4', '3' }, { '4', '4' }, { '4', '5' }, { '4', '6' }, { '4', '7' }, { '4', '8' }, { '4', '9' },
-    { '5', '0' }, { '5', '1' }, { '5', '2' }, { '5', '3' }, { '5', '4' }, { '5', '5' }, { '5', '6' }, { '5', '7' }, { '5', '8' }, { '5', '9' },
-    { '6', '0' }, { '6', '1' }, { '6', '2' }, { '6', '3' }, { '6', '4' }, { '6', '5' }, { '6', '6' }, { '6', '7' }, { '6', '8' }, { '6', '9' },
-    { '7', '0' }, { '7', '1' }, { '7', '2' }, { '7', '3' }, { '7', '4' }, { '7', '5' }, { '7', '6' }, { '7', '7' }, { '7', '8' }, { '7', '9' },
-    { '8', '0' }, { '8', '1' }, { '8', '2' }, { '8', '3' }, { '8', '4' }, { '8', '5' }, { '8', '6' }, { '8', '7' }, { '8', '8' }, { '8', '9' },
-    { '9', '0' }, { '9', '1' }, { '9', '2' }, { '9', '3' }, { '9', '4' }, { '9', '5' }, { '9', '6' }, { '9', '7' }, { '9', '8' }, { '9', '9' },
-};
-
-#undef NUL
-
-static u64_t mask24 = (u64(1) << 24) - 1;
-static u64_t mask32 = (u64(1) << 32) - 1;
-static u64_t mask57 = (u64(1) << 57) - 1;
-
-static 
-char* to_text_from_ulong(char* b, u64_t n) {
-    if (n < u32(1e2))
-    {
-        *cast_to_pair_ptr(b) = digits_fd[n];
+    if (n < u32(1e2)) {
+        COPY(b, digits_fd[n]);
         return n < 10 ? b + 1 : b + 2;
     }
-    if (n < u32(1e6))
-    {
-        if (n < u32(1e4))
-        {
+
+    if (n < u32(1e6)) {
+        if (n < u32(1e4)) {
             u32_t f0 = u32(10 * (1 << 24) / 1e3 + 1) * n;
-            *cast_to_pair_ptr(b) = digits_fd[f0 >> 24];
+            COPY(b, digits_fd[f0 >> 24]);
+
             b -= n < u32(1e3);
             u32_t f2 = (f0 & mask24) * 100;
-            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 24];
+            COPY(b + 2, digits_dd[f2 >> 24]);
+
             return b + 4;
         }
+
         u64_t f0 = u64(10 * (1ull << 32ull)/ 1e5 + 1) * n;
-        *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+        COPY(b, digits_fd[f0 >> 32]);
+
         b -= n < u32(1e5);
         u64_t f2 = (f0 & mask32) * 100;
-        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+        COPY(b + 2, digits_dd[f2 >> 32]);
+
         u64_t f4 = (f2 & mask32) * 100;
-        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+        COPY(b + 4, digits_dd[f4 >> 32]);
         return b + 6;
     }
-    if (n < u64(1ull << 32ull))
-    {
-        if (n < u32(1e8))
-        {
+
+    if (n < u64(1ull << 32ull)) {
+        if (n < u32(1e8)) {
             u64_t f0 = u64(10 * (1ull << 48ull) / 1e7 + 1) * n >> 16;
-            *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+            COPY(b, digits_fd[f0 >> 32]);
+
             b -= n < u32(1e7);
             u64_t f2 = (f0 & mask32) * 100;
-            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+            COPY(b + 2, digits_dd[f2 >> 32]);
+
             u64_t f4 = (f2 & mask32) * 100;
-            *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+            COPY(b + 4, digits_dd[f4 >> 32]);
+
             u64_t f6 = (f4 & mask32) * 100;
-            *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+            COPY(b + 6, digits_dd[f6 >> 32]);
+
             return b + 8;
         }
+
         u64_t f0 = u64(10 * (1ull << 57ull) / 1e9 + 1) * n;
-        *cast_to_pair_ptr(b) = digits_fd[f0 >> 57];
+        COPY(b, digits_fd[f0 >> 57]);
+
         b -= n < u32(1e9);
         u64_t f2 = (f0 & mask57) * 100;
-        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 57];
+        COPY(b + 2, digits_dd[f2 >> 57]);
+
         u64_t f4 = (f2 & mask57) * 100;
-        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 57];
+        COPY(b + 4, digits_dd[f4 >> 57]);
+
         u64_t f6 = (f4 & mask57) * 100;
-        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 57];
+        COPY(b + 6, digits_dd[f6 >> 57]);
+
         u64_t f8 = (f6 & mask57) * 100;
-        *cast_to_pair_ptr(b + 8) = digits_dd[f8 >> 57];
+        COPY(b + 8, digits_dd[f8 >> 57]);
+
         return b + 10;
     }
 
@@ -147,108 +154,121 @@ char* to_text_from_ulong(char* b, u64_t n) {
     u32_t z = n % u32(1e8);
     u64_t u = n / u32(1e8);
 
-    if (u < u32(1e2))
-    {
+    if (u < u32(1e2)) {
         // u can't be 1 digit (if u < 10 it would have been handled above as a 9 digit 32bit number)
-        *cast_to_pair_ptr(b) = digits_dd[u];
+        COPY(b, digits_dd[u]);
         b += 2;
     }
-    else if (u < u32(1e6))
-    {
-        if (u < u32(1e4))
-        {
+    else if (u < u32(1e6)) {
+        if (u < u32(1e4)) {
             u32_t f0 = u32(10 * (1 << 24) / 1e3 + 1) * u;
-            *cast_to_pair_ptr(b) = digits_fd[f0 >> 24];
+            COPY(b, digits_fd[f0 >> 24]);
+
             b -= u < u32(1e3);
             u32_t f2 = (f0 & mask24) * 100;
-            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 24];
+            COPY(b + 2, digits_dd[f2 >> 24]);
             b += 4;
         }
-        else
-        {
+        else {
             u64_t f0 = u64(10 * (1ull << 32ull) / 1e5 + 1) * u;
-            *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+            COPY(b, digits_fd[f0 >> 32]);
+
             b -= u < u32(1e5);
             u64_t f2 = (f0 & mask32) * 100;
-            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+            COPY(b + 2, digits_dd[f2 >> 32]);
+
             u64_t f4 = (f2 & mask32) * 100;
-            *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+            COPY(b + 4, digits_dd[f4 >> 32]);
             b += 6;
         }
     }
-    else if (u < u32(1e8))
-    {
+    else if (u < u32(1e8)) {
         u64_t f0 = u64(10 * (1ull << 48ull) / 1e7 + 1) * u >> 16;
-        *cast_to_pair_ptr(b) = digits_fd[f0 >> 32];
+        COPY(b, digits_fd[f0 >> 32]);
+
         b -= u < u32(1e7);
         u64_t f2 = (f0 & mask32) * 100;
-        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+        COPY(b + 2, digits_dd[f2 >> 32]);
+
         u64_t f4 = (f2 & mask32) * 100;
-        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+        COPY(b + 4, digits_dd[f4 >> 32]);
+
         u64_t f6 = (f4 & mask32) * 100;
-        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+        COPY(b + 6, digits_dd[f6 >> 32]);
+
         b += 8;
     }
-    else if (u < u64(1ull << 32ull))
-    {
+    else if (u < u64(1ull << 32ull)) {
         u64_t f0 = u64(10 * (1ull << 57ull) / 1e9 + 1) * u;
-        *cast_to_pair_ptr(b) = digits_fd[f0 >> 57];
+        COPY(b, digits_fd[f0 >> 57]);
+
         b -= u < u32(1e9);
         u64_t f2 = (f0 & mask57) * 100;
-        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 57];
+        COPY(b + 2, digits_dd[f2 >> 57]);
+
         u64_t f4 = (f2 & mask57) * 100;
-        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 57];
+        COPY(b + 4, digits_dd[f4 >> 57]);
+
         u64_t f6 = (f4 & mask57) * 100;
-        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 57];
+        COPY(b + 6, digits_dd[f6 >> 57]);
+
         u64_t f8 = (f6 & mask57) * 100;
-        *cast_to_pair_ptr(b + 8) = digits_dd[f8 >> 57];
+        COPY(b + 8, digits_dd[f8 >> 57]);
         b += 10;
     }
-    else
-    {
+    else {
         u32_t y = u % u32(1e8);
         u /= u32(1e8);
 
         // u is 2, 3, or 4 digits (if u < 10 it would have been handled above)
-        if (u < u32(1e2))
-        {
-            *cast_to_pair_ptr(b) = digits_dd[u];
+        if (u < u32(1e2)) {
+            COPY(b, digits_dd[u]);
             b += 2;
         }
-        else
-        {
+        else {
             u32_t f0 = u32(10 * (1 << 24) / 1e3 + 1) * u;
-            *cast_to_pair_ptr(b) = digits_fd[f0 >> 24];
+            COPY(b, digits_fd[f0 >> 24]);
+
             b -= u < u32(1e3);
             u32_t f2 = (f0 & mask24) * 100;
-            *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 24];
+            COPY(b + 2, digits_dd[f2 >> 24]);
+
             b += 4;
         }
         // do 8 digits
         u64_t f0 = (u64((1ull << 48ull) / 1e6 + 1) * y >> 16) + 1;
-        *cast_to_pair_ptr(b) = digits_dd[f0 >> 32];
+        COPY(b, digits_dd[f0 >> 32]);
+
         u64_t f2 = (f0 & mask32) * 100;
-        *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+        COPY(b + 2, digits_dd[f2 >> 32]);
+
         u64_t f4 = (f2 & mask32) * 100;
-        *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+        COPY(b + 4, digits_dd[f4 >> 32]);
+
         u64_t f6 = (f4 & mask32) * 100;
-        *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+        COPY(b + 6, digits_dd[f6 >> 32]);
         b += 8;
     }
+
     // do 8 digits
     u64_t f0 = (u64((1ull << 48ull) / 1e6 + 1) * z >> 16) + 1;
-    *cast_to_pair_ptr(b) = digits_dd[f0 >> 32];
+    COPY(b, digits_dd[f0 >> 32]);
+
     u64_t f2 = (f0 & mask32) * 100;
-    *cast_to_pair_ptr(b + 2) = digits_dd[f2 >> 32];
+    COPY(b + 2, digits_dd[f2 >> 32]);
+
     u64_t f4 = (f2 & mask32) * 100;
-    *cast_to_pair_ptr(b + 4) = digits_dd[f4 >> 32];
+    COPY(b + 4, digits_dd[f4 >> 32]);
+
     u64_t f6 = (f4 & mask32) * 100;
-    *cast_to_pair_ptr(b + 6) = digits_dd[f6 >> 32];
+    COPY(b + 6, digits_dd[f6 >> 32]);
+
     return b + 8;
 }
 
 #undef u32
 #undef u64
+#undef COPY
 
 #pragma clang diagnostic pop
 #pragma GCC diagnostic pop

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -707,4 +707,16 @@ class JSONGeneratorTest < Test::Unit::TestCase
         assert_equal expected, value.to_json
       end
   end
+  
+  def test_numbers_of_various_sizes
+    numbers = [
+      0, 1, -1, 9, -9, 13, -13, 91, -91, 513, -513, 7513, -7513,
+      17591, -17591, -4611686018427387904, 4611686018427387903,
+      2**62, 2**63, 2**64, -(2**62), -(2**63), -(2**64)
+    ]
+
+    numbers.each do |number|
+      assert_equal "[#{number}]", JSON.generate([number])
+    end
+  end
 end


### PR DESCRIPTION
This PR provides an alternative implementation for a long → decimal conversion.

The main difference is that it uses an algorithm pulled from https://github.com/jeaiii/itoa. The source there is C++, it was converted by hand to C for inclusion with this gem. A writeup of this algorithm can be found [here](https://jk-jeon.github.io/posts/2022/02/jeaiii-algorithm/). jeaiii's algorithm is covered by the MIT License, see source code.

On addition this version now also generates the string directly into the `fbuffer`, foregoing the need to run a separate memory copy.

As a result, I see a speedup of 32% on Apple Silicon M1 for an integer set of benchmarks. 

```
== Encoding ints (45025 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
        json (local)     1.566k i/100ms
Calculating -------------------------------------
        json (local)     16.322k (± 3.9%) i/s   (61.27 μs/i) -     82.998k in   5.093499s

Normalize to 8009 byte
== Encoding ints (45025 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
       json (2.10.2)     1.228k i/100ms
Calculating -------------------------------------
       json (2.10.2)     12.352k (± 0.5%) i/s   (80.96 μs/i) -     62.628k in   5.070472s
```

These benchmarks are run via a script ([link](https://gist.github.com/radiospiel/04019402726a28b31616df3d0c17bd1c)) which is based on the gem's `benchmark/encoder.rb` file. There are probably better ways to run benchmarks :) My version allows to combine multiple test cases into a single one. 

The script adds a "cents" test case ([link](https://gist.github.com/radiospiel/04019402726a28b31616df3d0c17bd1c#file-encoder-rb-L188)) which explicitly covers integers in a range that is relevant for financial institutions. (Comparing benchmarks for that case show a speedup of 41%)

The `dumps` benchmark, which covers the JSON files in `benchmark/data/*.json`, sees a speedup of ~8 %.



