### PR TITLE
Removed trailing space

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1077,7 +1077,7 @@ static void generate_json_float(FBuffer *buffer, struct generate_json_data *data
 
     /* This implementation writes directly into the buffer. We reserve
      * the 24 characters that fpconv_dtoa states as its maximum, plus
-     * 2 more characters for the potential ".0" suffix. 
+     * 2 more characters for the potential ".0" suffix.
      */
     fbuffer_inc_capa(buffer, 26);
     char* d = buffer->ptr + buffer->len;


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/6b15857e2563cec0b38e6bce7646c1a9abaf4ba3