### PR TITLE
Remove `unparse` and `restore` aliases.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 * Deprecate `JSON.load_default_options`.
 * Deprecate `JSON.unsafe_load_default_options`.
 * Deprecate `JSON.dump_default_options`.
+* Remove deprecated `JSON.restore` method.
+* Remove deprecated `JSON.unparse` method.
+* Remove deprecated `JSON.fast_unparse` method.
+* Remove deprecated `JSON.pretty_unparse` method.
 
 ### 2025-03-12 (2.10.2)
 

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -357,13 +357,6 @@ module JSON
     end
   end
 
-  # :stopdoc:
-  # I want to deprecate these later, so I'll first be silent about them, and
-  # later delete them.
-  alias unparse generate
-  module_function :unparse
-  # :startdoc:
-
   # :call-seq:
   #   JSON.fast_generate(obj, opts) -> new_string
   #
@@ -385,12 +378,6 @@ module JSON
     end
     state.generate(obj)
   end
-
-  # :stopdoc:
-  # I want to deprecate these later, so I'll first be silent about them, and later delete them.
-  alias fast_unparse fast_generate
-  module_function :fast_unparse
-  # :startdoc:
 
   # :call-seq:
   #   JSON.pretty_generate(obj, opts = nil) -> new_string
@@ -440,12 +427,6 @@ module JSON
     end
     state.generate(obj)
   end
-
-  # :stopdoc:
-  # I want to deprecate these later, so I'll first be silent about them, and later delete them.
-  alias pretty_unparse pretty_generate
-  module_function :pretty_unparse
-  # :startdoc:
 
   # Sets or returns default options for the JSON.unsafe_load method.
   # Initially:
@@ -798,9 +779,6 @@ module JSON
       proc.call result
     end
   end
-
-  alias restore load
-  module_function :restore
 
   # Sets or returns the default options for the JSON.dump method.
   # Initially:


### PR DESCRIPTION
These were deprecated 16 years ago.