### PR TITLE
Get rid of SAFE_STATE_PROTOTYPE

### DIFF
--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -158,8 +158,7 @@ public class GeneratorState extends RubyObject {
             }
         }
 
-        // for other values, return the safe prototype
-        return (GeneratorState)info.getSafeStatePrototype(context).dup();
+        return (GeneratorState)klass.newInstance(context, context.nil);
     }
 
     /**

--- a/java/src/json/ext/RuntimeInfo.java
+++ b/java/src/json/ext/RuntimeInfo.java
@@ -30,8 +30,6 @@ final class RuntimeInfo {
     WeakReference<RubyModule> jsonModule;
     /** JSON::Ext::Generator::State */
     WeakReference<RubyClass> generatorStateClass;
-    /** JSON::SAFE_STATE_PROTOTYPE */
-    WeakReference<GeneratorState> safeStatePrototype;
 
     private RuntimeInfo() {
     }
@@ -66,16 +64,5 @@ final class RuntimeInfo {
             assert cache != null : "Runtime given has not initialized JSON::Ext";
             return cache;
         }
-    }
-
-    public GeneratorState getSafeStatePrototype(ThreadContext context) {
-        if (safeStatePrototype == null) {
-            IRubyObject value = jsonModule.get().getConstant("SAFE_STATE_PROTOTYPE");
-            if (!(value instanceof GeneratorState)) {
-                throw context.runtime.newTypeError(value, generatorStateClass.get());
-            }
-            safeStatePrototype = new WeakReference<>((GeneratorState) value);
-        }
-        return safeStatePrototype.get();
     }
 }

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -70,7 +70,6 @@ module JSON
       end
       self.state = generator::State
       const_set :State, self.state
-      const_set :SAFE_STATE_PROTOTYPE, State.new # for JRuby
     ensure
       $VERBOSE = old
     end

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -117,7 +117,7 @@ module JSON
               return new(opts.to_h)
             end
           end
-          SAFE_STATE_PROTOTYPE.dup
+          new
         end
 
         # Instantiates a new State object, configured by _opts_.


### PR DESCRIPTION
It was only used by JRuby and TruffleRuby to call `SAFE_STATE_PROTOTYPE.dup` instead of `State.new` which isn't an worthy optimization.