### PR TITLE
Relax assertion pattern for ruby repo

### DIFF
--- a/test/json/json_addition_test.rb
+++ b/test/json/json_addition_test.rb
@@ -152,7 +152,7 @@ class JSONAdditionTest < Test::Unit::TestCase
 
   def test_deprecated_load_create_additions
     pattern = /json_addition_test\.rb.*use JSON\.unsafe_load/
-    if RUBY_ENGINE == 'truffleruby'
+    if RUBY_ENGINE == 'truffleruby' || File.basename($0) != 'json_addition_test.rb'
       pattern = /use JSON\.unsafe_load/
     end
 


### PR DESCRIPTION
`test_deprecated_load_create_additions` is failing on ruby/ruby repo(https://github.com/ruby/ruby/pull/13004):

```
  1) Failure:
JSONAdditionTest#test_deprecated_load_create_additions [/Users/hsbt/Documents/github.com/ruby/ruby/test/json/json_addition_test.rb:159]:
expected: /json_addition_test\.rb.*use JSON\.unsafe_load/
actual: "/Users/hsbt/Documents/github.com/ruby/ruby/.ext/common/json/common.rb:860: warning: JSON.load implicit support for `create_additions: true` is deprecated and will be removed in 3.0, use JSON.unsafe_load or explicitly pass `create_additions: true`\n".
```

I'm not sure this fix is good for this test. @byroot Could you review this?