### PR TITLE
Remove unnecessary conditional in escape_UTF8_char_basic.

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -189,15 +189,11 @@ static inline FORCE_INLINE void escape_UTF8_char_basic(search_state *search)
         case '\r': fbuffer_append(search->buffer, "\\r", 2);  break;
         case '\t': fbuffer_append(search->buffer, "\\t", 2);  break;
         default: {
-            if (ch < ' ') {
-                const char *hexdig = "0123456789abcdef";
-                char scratch[6] = { '\\', 'u', '0', '0', 0, 0 };
-                scratch[4] = hexdig[(ch >> 4) & 0xf];
-                scratch[5] = hexdig[ch & 0xf];
-                fbuffer_append(search->buffer, scratch, 6);
-            } else {
-                fbuffer_append_char(search->buffer, ch);
-            }
+            const char *hexdig = "0123456789abcdef";
+            char scratch[6] = { '\\', 'u', '0', '0', 0, 0 };
+            scratch[4] = hexdig[(ch >> 4) & 0xf];
+            scratch[5] = hexdig[ch & 0xf];
+            fbuffer_append(search->buffer, scratch, 6);
             break;
         }
     }


### PR DESCRIPTION
This conditional was added with the popcount heuristic as it would call `escape_UTF8_char_basic` for all characters in a chunk even if they didn't need to be escaped. Without that this isn't necessary as `search_escape_basic*` will always return non-zero when `search->ptr` is pointing to a character that needs to be escaped.