### PR TITLE
Improve parser error messages to include line and column numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Include line and column in parser errors. Both in the message and as exception attributes.
 * Handle non-string hash keys with broken `to_s` implementations.
 * `JSON.generate` now uses SSE2 (x86) or NEON (arm64) instructions when available to escape strings.
 

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -230,7 +230,9 @@ module JSON
   class JSONError < StandardError; end
 
   # This exception is raised if a parser error occurs.
-  class ParserError < JSONError; end
+  class ParserError < JSONError
+    attr_reader :line, :column
+  end
 
   # This exception is raised if the nesting of parsed data structures is too
   # deep.

--- a/test/json/json_ext_parser_test.rb
+++ b/test/json/json_ext_parser_test.rb
@@ -15,15 +15,19 @@ class JSONExtParserTest < Test::Unit::TestCase
 
   def test_error_messages
     ex = assert_raise(ParserError) { parse('Infinity') }
-    assert_equal "unexpected token at 'Infinity'", ex.message
-
     unless RUBY_PLATFORM =~ /java/
-      ex = assert_raise(ParserError) { parse('-Infinity') }
-      assert_equal "unexpected token at '-Infinity'", ex.message
+      assert_equal "unexpected token 'Infinity' at line 1 column 1", ex.message
+    end
+
+    ex = assert_raise(ParserError) { parse('-Infinity') }
+    unless RUBY_PLATFORM =~ /java/
+      assert_equal "unexpected token '-Infinity' at line 1 column 1", ex.message
     end
 
     ex = assert_raise(ParserError) { parse('NaN') }
-    assert_equal "unexpected token at 'NaN'", ex.message
+    unless RUBY_PLATFORM =~ /java/
+      assert_equal "unexpected token 'NaN' at line 1 column 1", ex.message
+    end
   end
 
   if GC.respond_to?(:stress=)

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -638,7 +638,7 @@ class JSONParserTest < Test::Unit::TestCase
     error = assert_raise(JSON::ParserError) do
       JSON.parse('{"foo": ' + ('A' * 500) + '}')
     end
-    assert_operator 60, :>, error.message.bytesize
+    assert_operator 80, :>, error.message.bytesize
   end
 
   def test_parse_error_incomplete_hash
@@ -646,7 +646,7 @@ class JSONParserTest < Test::Unit::TestCase
       JSON.parse('{"input":{"firstName":"Bob","lastName":"Mob","email":"bob@example.com"}')
     end
     if RUBY_ENGINE == "ruby"
-      assert_equal %(expected ',' or '}' after object value, got: ''), error.message
+      assert_equal %(expected ',' or '}' after object value, got: '' at line 1 column 72), error.message
     end
   end
 
@@ -654,16 +654,16 @@ class JSONParserTest < Test::Unit::TestCase
     omit "C ext only test" unless RUBY_ENGINE == "ruby"
 
     error = assert_raise(JSON::ParserError) { JSON.parse("あああああああああああああああああああああああ") }
-    assert_equal "unexpected character: 'ああああああああああ'", error.message
+    assert_equal "unexpected character: 'ああああああああああ' at line 1 column 1", error.message
 
     error = assert_raise(JSON::ParserError) { JSON.parse("aあああああああああああああああああああああああ") }
-    assert_equal "unexpected character: 'aああああああああああ'", error.message
+    assert_equal "unexpected character: 'aああああああああああ' at line 1 column 1", error.message
 
     error = assert_raise(JSON::ParserError) { JSON.parse("abあああああああああああああああああああああああ") }
-    assert_equal "unexpected character: 'abあああああああああ'", error.message
+    assert_equal "unexpected character: 'abあああああああああ' at line 1 column 1", error.message
 
     error = assert_raise(JSON::ParserError) { JSON.parse("abcあああああああああああああああああああああああ") }
-    assert_equal "unexpected character: 'abcあああああああああ'", error.message
+    assert_equal "unexpected character: 'abcあああああああああ' at line 1 column 1", error.message
   end
 
   def test_parse_leading_slash


### PR DESCRIPTION
The title says it all.

The line and column are also accessible as attributes on the exception object.

NB: this is only for the C version. The Java version would require quite a big refactor and I don't have the time or energy for it.