### PR TITLE
Fix SIMD conf

### DIFF
--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -9,7 +9,7 @@ else
   $defs << "-DJSON_DEBUG" if ENV["JSON_DEBUG"]
 
   if enable_config('generator-use-simd', default=!ENV["JSON_DISABLE_SIMD"])
-    require_relative "../simd/conf.rb"
+    load __dir__ + "/../simd/conf.rb"
   end
 
   create_makefile 'json/ext/generator'

--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -9,7 +9,7 @@ have_func("strnlen", "string.h") # Missing on Solaris 10
 append_cflags("-std=c99")
 
 if enable_config('parser-use-simd', default=!ENV["JSON_DISABLE_SIMD"])
-  require_relative "../simd/conf.rb"
+  load __dir__ + "/../simd/conf.rb"
 end
 
 create_makefile 'json/ext/parser'

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -908,7 +908,7 @@ static inline bool FORCE_INLINE string_scan(JSON_ParserState *state)
 {
 #ifdef HAVE_SIMD
 #if defined(HAVE_SIMD_NEON)
-    
+
     uint64_t mask = 0;
     if (string_scan_simd_neon(&state->cursor, state->end, &mask)) {
         state->cursor += trailing_zeros64(mask) >> 2;

--- a/ext/json/ext/simd/conf.rb
+++ b/ext/json/ext/simd/conf.rb
@@ -2,7 +2,7 @@ case RbConfig::CONFIG['host_cpu']
 when /^(arm|aarch64)/
   # Try to compile a small program using NEON instructions
   if have_header('arm_neon.h') &&
-     have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
+     try_compile(<<~'SRC')
       #include <arm_neon.h>
       int main(int argc, char **argv) {
           uint8x16_t test = vdupq_n_u8(32);
@@ -14,7 +14,7 @@ when /^(arm|aarch64)/
   end
 when /^(x86_64|x64)/
   if have_header('x86intrin.h') &&
-     have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
+     try_compile(<<~'SRC')
       #include <x86intrin.h>
       int main(int argc, char **argv) {
           __m128i test = _mm_set1_epi8(32);

--- a/ext/json/ext/simd/conf.rb
+++ b/ext/json/ext/simd/conf.rb
@@ -1,4 +1,5 @@
-if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
+case RbConfig::CONFIG['host_cpu']
+when /^(arm|aarch64)/
   # Try to compile a small program using NEON instructions
   if have_header('arm_neon.h')
     have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
@@ -8,20 +9,20 @@ if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
           if (argc > 100000) printf("%p", &test);
           return 0;
       }
-    SRC
-      $defs.push("-DJSON_ENABLE_SIMD")
-  end
-end
-
-if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
-  #include <x86intrin.h>
-  int main(int argc, char **argv) {
-      __m128i test = _mm_set1_epi8(32);
-      if (argc > 100000) printf("%p", &test);
-      return 0;
-  }
-  SRC
+      SRC
     $defs.push("-DJSON_ENABLE_SIMD")
+  end
+when /^(x86_64|x64)/
+  if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
+      #include <x86intrin.h>
+      int main(int argc, char **argv) {
+          __m128i test = _mm_set1_epi8(32);
+          if (argc > 100000) printf("%p", &test);
+          return 0;
+      }
+      SRC
+    $defs.push("-DJSON_ENABLE_SIMD")
+  end
 end
 
 have_header('cpuid.h')

--- a/ext/json/ext/simd/conf.rb
+++ b/ext/json/ext/simd/conf.rb
@@ -1,8 +1,8 @@
 case RbConfig::CONFIG['host_cpu']
 when /^(arm|aarch64)/
   # Try to compile a small program using NEON instructions
-  if have_header('arm_neon.h')
-    have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
+  if have_header('arm_neon.h') &&
+     have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
       #include <arm_neon.h>
       int main(int argc, char **argv) {
           uint8x16_t test = vdupq_n_u8(32);
@@ -13,7 +13,8 @@ when /^(arm|aarch64)/
     $defs.push("-DJSON_ENABLE_SIMD")
   end
 when /^(x86_64|x64)/
-  if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
+  if have_header('x86intrin.h') &&
+     have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
       #include <x86intrin.h>
       int main(int argc, char **argv) {
           __m128i test = _mm_set1_epi8(32);

--- a/ext/json/ext/simd/conf.rb
+++ b/ext/json/ext/simd/conf.rb
@@ -3,8 +3,9 @@ if RbConfig::CONFIG['host_cpu'] =~ /^(arm.*|aarch64.*)/
   if have_header('arm_neon.h')
     have_type('uint8x16_t', headers=['arm_neon.h']) && try_compile(<<~'SRC')
       #include <arm_neon.h>
-      int main() {
+      int main(int argc, char **argv) {
           uint8x16_t test = vdupq_n_u8(32);
+          if (argc > 100000) printf("%p", &test);
           return 0;
       }
     SRC
@@ -14,8 +15,9 @@ end
 
 if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
   #include <x86intrin.h>
-  int main() {
+  int main(int argc, char **argv) {
       __m128i test = _mm_set1_epi8(32);
+      if (argc > 100000) printf("%p", &test);
       return 0;
   }
   SRC


### PR DESCRIPTION
`require`d  file does not run twice, SIMD is not enabled one of generator and parser, when the extconf files are run in the same process.

And refactored `simd/conf.rb`.