### PR TITLE
Suppress -Wunused-function

### DIFF
--- a/ext/json/ext/simd/simd.h
+++ b/ext/json/ext/simd/simd.h
@@ -59,7 +59,7 @@ static inline int trailing_zeros(int input) {
 #include <arm_neon.h>
 
 #define FIND_SIMD_IMPLEMENTATION_DEFINED 1
-static SIMD_Implementation find_simd_implementation(void) {
+static inline SIMD_Implementation find_simd_implementation(void) {
     return SIMD_NEON;
 }
 
@@ -161,7 +161,7 @@ static inline TARGET_SSE2 FORCE_INLINE int string_scan_simd_sse2(const char **pt
 #include <cpuid.h>
 #endif /* HAVE_CPUID_H */
 
-static SIMD_Implementation find_simd_implementation(void) {
+static inline SIMD_Implementation find_simd_implementation(void) {
 
 #if defined(__GNUC__ ) || defined(__clang__)
 #ifdef __GNUC__
@@ -183,7 +183,7 @@ static SIMD_Implementation find_simd_implementation(void) {
 #endif /* JSON_ENABLE_SIMD */
 
 #ifndef FIND_SIMD_IMPLEMENTATION_DEFINED
-static SIMD_Implementation find_simd_implementation(void) {
+static inline SIMD_Implementation find_simd_implementation(void) {
     return SIMD_NONE;
 }
 #endif


### PR DESCRIPTION
I saw a compiler warning when compiling ruby/ruby. This PR attempts to suppress it by making it an inline function, which is usually not warned by `-Wunused-function`.

```
In file included from ../../../../ext/json/parser/parser.c:23:
../../../../ext/json/parser/../simd/simd.h:186:28: warning: ‘find_simd_implementation’ defined but not used [-Wunused-function]
  186 | static SIMD_Implementation find_simd_implementation(void) {
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~
```

I'm not sure why it's happening (or `HAVE_SIMD` is not defined) on my ruby build, but it does seem unused in parser.c when `HAVE_SIMD` is not defined. So it does seem like a legit warning in some cases.