### PR TITLE
Use Dir.glob and base keyword arg for the installer of Ruby package

### DIFF
--- a/json.gemspec
+++ b/json.gemspec
@@ -44,8 +44,7 @@ spec = Gem::Specification.new do |s|
     "LEGAL",
     "README.md",
     "json.gemspec",
-    *Dir["lib/**/*.rb"],
-  ]
+  ] + Dir.glob("lib/**/*.rb", base: File.expand_path("..", __FILE__))
 
   if java_ext
     s.platform = 'java'


### PR DESCRIPTION
for https://bugs.ruby-lang.org/issues/21462