### PR TITLE
Use Vector API in the Java Extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ JAVA_DIR            = "java/src/json/ext"
 JAVA_RAGEL_PATH     = "#{JAVA_DIR}/ParserConfig.rl"
 JAVA_PARSER_SRC     = "#{JAVA_DIR}/ParserConfig.java"
 JAVA_SOURCES        = FileList["#{JAVA_DIR}/*.java"]
+JAVA_VEC_SOURCES    = FileList["#{JAVA_DIR}/vectorized/*.java"]
 JAVA_CLASSES        = []
 JRUBY_PARSER_JAR    = File.expand_path("lib/json/ext/parser.jar")
 JRUBY_GENERATOR_JAR = File.expand_path("lib/json/ext/generator.jar")
@@ -68,7 +69,8 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
       classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * ':'
       obj = src.sub(/\.java\Z/, '.class')
       file obj => src do
-        sh 'javac', '--enable-preview', '--add-modules', 'jdk.incubator.vector', '-classpath', classpath, '-source', '21', '-target', '21', src
+        sh 'javac', '-classpath', classpath, '-source', '1.8', '-target', '1.8', src
+        # '--enable-preview', '--add-modules', 'jdk.incubator.vector', 
       end
       JAVA_CLASSES << obj
     end

--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
       classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * ':'
       obj = src.sub(/\.java\Z/, '.class')
       file obj => src do
-        sh 'javac', '-classpath', classpath, '-source', '1.8', '-target', '1.8', src
+        sh 'javac', '--enable-preview', '--add-modules', 'jdk.incubator.vector', '-classpath', classpath, '-source', '21', '-target', '21', src
       end
       JAVA_CLASSES << obj
     end
@@ -117,11 +117,14 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
       generator_classes = FileList[
         "json/ext/ByteList*.class",
         "json/ext/OptionsReader*.class",
+        "json/ext/EscapeScanner*.class",
         "json/ext/Generator*.class",
         "json/ext/RuntimeInfo*.class",
         "json/ext/StringEncoder*.class",
-        "json/ext/Utils*.class"
+        "json/ext/Utils*.class",
+        "json/ext/VectorizedEscapeScanner*.class"
       ]
+      puts "Creating generator jar with classes: #{generator_classes.join(', ')}"
       sh 'jar', 'cf', File.basename(JRUBY_GENERATOR_JAR), *generator_classes
       mv File.basename(JRUBY_GENERATOR_JAR), File.dirname(JRUBY_GENERATOR_JAR)
     end

--- a/java/src/json/ext/EscapeScanner.java
+++ b/java/src/json/ext/EscapeScanner.java
@@ -1,0 +1,75 @@
+package json.ext;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+
+interface EscapeScanner {
+    static class State {
+        byte[] ptrBytes;
+        int ptr;
+        int len;
+        int pos;
+        int beg;
+        int ch;
+    }
+
+    static class VectorSupport {
+        static Constructor<?> vectorizedEscapeScannerConstructor = null;
+
+        static {
+            Optional<Module> vectorModule = ModuleLayer.boot().findModule("jdk.incubator.vector");
+            if (vectorModule.isPresent()) {
+                try {
+                    Class<?> vectorEscapeScannerClass = EscapeScanner.class.getClassLoader().loadClass("json.ext.VectorizedEscapeScanner");
+                    vectorizedEscapeScannerConstructor = vectorEscapeScannerClass.getDeclaredConstructor();
+                } catch (ClassNotFoundException | NoSuchMethodException e) {
+                    // Fallback to the ScalarEscapeScanner if we cannot load the VectorizedEscapeScanner.
+                    System.err.println("Failed to load VectorizedEscapeScanner, falling back to ScalarEscapeScanner: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    boolean scan(EscapeScanner.State state) throws java.io.IOException;
+
+    public static EscapeScanner basicScanner() {
+        if (VectorSupport.vectorizedEscapeScannerConstructor != null) {
+            try {
+                // Attempt to instantiate the vectorized escape scanner if available.
+                return (EscapeScanner) VectorSupport.vectorizedEscapeScannerConstructor.newInstance();
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                System.err.println("Failed to instantiate VectorizedEscapeScanner, falling back to ScalarEscapeScanner: " + e.getMessage());
+            }
+
+        }
+
+        return new ScalarEscapeScanner(StringEncoder.ESCAPE_TABLE);
+    }
+
+    public static EscapeScanner create(byte[] escapeTable) {
+        return new ScalarEscapeScanner(escapeTable);
+    }
+
+    public static class ScalarEscapeScanner implements EscapeScanner {
+        private final byte[] escapeTable;
+
+        public ScalarEscapeScanner(byte[] escapeTable) {
+            this.escapeTable = escapeTable;
+        }
+
+        @Override
+        public boolean scan(EscapeScanner.State state) throws java.io.IOException {
+            while (state.pos < state.len) {
+                state.ch = Byte.toUnsignedInt(state.ptrBytes[state.ptr + state.pos]);
+                int ch_len = escapeTable[state.ch];
+                if (ch_len > 0) {
+                    return true;
+                }
+                state.pos++;
+            }
+            return false;
+        }
+
+    }
+}

--- a/java/src/json/ext/EscapeScanner.java
+++ b/java/src/json/ext/EscapeScanner.java
@@ -15,33 +15,42 @@ interface EscapeScanner {
     }
 
     static class VectorSupport {
-        static Constructor<?> vectorizedEscapeScannerConstructor = null;
+        static final EscapeScanner VECTORIZED_ESCAPE_SCANNER;
 
         static {
             Optional<Module> vectorModule = ModuleLayer.boot().findModule("jdk.incubator.vector");
+            EscapeScanner scanner = null;
             if (vectorModule.isPresent()) {
                 try {
                     Class<?> vectorEscapeScannerClass = EscapeScanner.class.getClassLoader().loadClass("json.ext.VectorizedEscapeScanner");
-                    vectorizedEscapeScannerConstructor = vectorEscapeScannerClass.getDeclaredConstructor();
-                } catch (ClassNotFoundException | NoSuchMethodException e) {
+                    Constructor<?> vectorizedEscapeScannerConstructor = vectorEscapeScannerClass.getDeclaredConstructor();
+                    scanner = (EscapeScanner) vectorizedEscapeScannerConstructor.newInstance();
+                } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                     // Fallback to the ScalarEscapeScanner if we cannot load the VectorizedEscapeScanner.
                     System.err.println("Failed to load VectorizedEscapeScanner, falling back to ScalarEscapeScanner: " + e.getMessage());
+                    scanner = null;
                 }
+                
             }
+            VECTORIZED_ESCAPE_SCANNER = scanner;
         }
     }
 
     boolean scan(EscapeScanner.State state) throws java.io.IOException;
 
-    public static EscapeScanner basicScanner() {
-        if (VectorSupport.vectorizedEscapeScannerConstructor != null) {
-            try {
-                // Attempt to instantiate the vectorized escape scanner if available.
-                return (EscapeScanner) VectorSupport.vectorizedEscapeScannerConstructor.newInstance();
-            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                System.err.println("Failed to instantiate VectorizedEscapeScanner, falling back to ScalarEscapeScanner: " + e.getMessage());
-            }
+    default State createState(byte[] ptrBytes, int ptr, int len, int beg) {
+        State state = new State();
+        state.ptrBytes = ptrBytes;
+        state.ptr = ptr;
+        state.len = len;
+        state.beg = beg;
+        state.pos = 0; // Start scanning from the beginning of the segment
+        return state;
+    }
 
+    public static EscapeScanner basicScanner() {
+        if (VectorSupport.VECTORIZED_ESCAPE_SCANNER != null) {
+            return VectorSupport.VECTORIZED_ESCAPE_SCANNER;
         }
 
         return new ScalarEscapeScanner(StringEncoder.ESCAPE_TABLE);

--- a/java/src/json/ext/EscapeScanner.java
+++ b/java/src/json/ext/EscapeScanner.java
@@ -15,22 +15,19 @@ interface EscapeScanner {
     }
 
     static class VectorSupport {
+        private static String VECTORIZED_ESCAPE_SCANNER_CLASS = "json.ext.vectorized.VectorizedEscapeScanner";
         static final EscapeScanner VECTORIZED_ESCAPE_SCANNER;
 
         static {
-            Optional<Module> vectorModule = ModuleLayer.boot().findModule("jdk.incubator.vector");
             EscapeScanner scanner = null;
-            if (vectorModule.isPresent()) {
-                try {
-                    Class<?> vectorEscapeScannerClass = EscapeScanner.class.getClassLoader().loadClass("json.ext.VectorizedEscapeScanner");
-                    Constructor<?> vectorizedEscapeScannerConstructor = vectorEscapeScannerClass.getDeclaredConstructor();
-                    scanner = (EscapeScanner) vectorizedEscapeScannerConstructor.newInstance();
-                } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                    // Fallback to the ScalarEscapeScanner if we cannot load the VectorizedEscapeScanner.
-                    System.err.println("Failed to load VectorizedEscapeScanner, falling back to ScalarEscapeScanner: " + e.getMessage());
-                    scanner = null;
-                }
-                
+            try {
+                Class<?> vectorEscapeScannerClass = EscapeScanner.class.getClassLoader().loadClass(VECTORIZED_ESCAPE_SCANNER_CLASS);
+                Constructor<?> vectorizedEscapeScannerConstructor = vectorEscapeScannerClass.getDeclaredConstructor();
+                scanner = (EscapeScanner) vectorizedEscapeScannerConstructor.newInstance();
+            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                // Fallback to the ScalarEscapeScanner if we cannot load the VectorizedEscapeScanner.
+                System.err.println("Failed to load VectorizedEscapeScanner, falling back to ScalarEscapeScanner: " + e.getMessage());
+                scanner = null;
             }
             VECTORIZED_ESCAPE_SCANNER = scanner;
         }

--- a/java/src/json/ext/EscapeScanner.java
+++ b/java/src/json/ext/EscapeScanner.java
@@ -2,7 +2,6 @@ package json.ext;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Optional;
 
 interface EscapeScanner {
     static class State {

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -232,7 +232,7 @@ public final class Generator {
                 GeneratorState state = getState(context);
                 stringEncoder = state.asciiOnly() ?
                         new StringEncoderAsciiOnly(state.scriptSafe()) :
-                        new StringEncoder(state.scriptSafe());
+                        state.scriptSafe() ? StringEncoder.scriptSafeEncoder() : StringEncoder.basicEncoder();
             }
             return stringEncoder;
         }

--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -21,10 +21,6 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
 
-import jdk.incubator.vector.ByteVector;
-import jdk.incubator.vector.VectorSpecies;
-import json.ext.VectorizedEscapeScanner;
-
 /**
  * An encoder that reads from the given source and outputs its representation
  * to another ByteList. The source string is fully checked for UTF-8 validity,

--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -228,17 +228,18 @@ class StringEncoder extends ByteListTranscoder {
     }
 
     void encodeBasic(ByteList src) throws IOException {
-        EscapeScanner.State state = new EscapeScanner.State();
-        state.ptrBytes = src.unsafeBytes();
-        state.ptr = src.begin();
-        state.len = src.realSize();
-        state.beg = 0;
-        state.pos = 0;
+        // EscapeScanner.State state = new EscapeScanner.State();
+        // state.ptrBytes = src.unsafeBytes();
+        // state.ptr = src.begin();
+        // state.len = src.realSize();
+        // state.beg = 0;
+        // state.pos = 0;
 
         byte[] hexdig = HEX;
         byte[] scratch = aux;
 
         EscapeScanner scanner = EscapeScanner.basicScanner();
+        EscapeScanner.State state = scanner.createState(src.unsafeBytes(), src.begin(), src.realSize(), 0);
 
         while(scanner.scan(state)) {
             int ch = Byte.toUnsignedInt(state.ptrBytes[state.ptr + state.pos]);

--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -224,13 +224,6 @@ class StringEncoder extends ByteListTranscoder {
     }
 
     void encodeBasic(ByteList src) throws IOException {
-        // EscapeScanner.State state = new EscapeScanner.State();
-        // state.ptrBytes = src.unsafeBytes();
-        // state.ptr = src.begin();
-        // state.len = src.realSize();
-        // state.beg = 0;
-        // state.pos = 0;
-
         byte[] hexdig = HEX;
         byte[] scratch = aux;
 
@@ -306,44 +299,6 @@ class StringEncoder extends ByteListTranscoder {
                 state.pos++;
             }
         }
-
-        // while (state.pos < state.len) {
-        //     int ch = Byte.toUnsignedInt(state.ptrBytes[state.ptr + state.pos]);
-        //     int ch_len = escapeTable[ch];
-        //     /* JSON encoding */
-
-        //     if (ch_len > 0) {
-        //         switch (ch_len) {
-        //             case 9: {
-        //                 state.beg = state.pos = flushPos(state.pos, state.beg, state.ptrBytes, state.ptr, 1);
-        //                 escapeAscii(ch, scratch, hexdig);
-        //                 break;
-        //             }
-        //             case 11: {
-        //                 int b2 = Byte.toUnsignedInt(state.ptrBytes[state.ptr + state.pos + 1]);
-        //                 if (b2 == 0x80) {
-        //                     int b3 = Byte.toUnsignedInt(state.ptrBytes[state.ptr + state.pos + 2]);
-        //                     if (b3 == 0xA8) {
-        //                         state.beg = state.pos = flushPos(state.pos, state.beg, state.ptrBytes, state.ptr, 3);
-        //                         append(BACKSLASH_U2028, 0, 6);
-        //                         break;
-        //                     } else if (b3 == 0xA9) {
-        //                         state.beg = state.pos = flushPos(state.pos, state.beg, state.ptrBytes, state.ptr, 3);
-        //                         append(BACKSLASH_U2029, 0, 6);
-        //                         break;
-        //                     }
-        //                 }
-        //                 ch_len = 3;
-        //                 // fallthrough
-        //             }
-        //             default:
-        //                 state.pos += ch_len;
-        //                 break;
-        //         }
-        //     } else {
-        //         state.pos++;
-        //     }
-        // }
 
         if (state.beg < state.len) {
             append(state.ptrBytes, state.ptr + state.beg, state.len - state.beg);

--- a/java/src/json/ext/VectorizedEscapeScanner.java
+++ b/java/src/json/ext/VectorizedEscapeScanner.java
@@ -1,13 +1,11 @@
 package json.ext;
 
 import java.io.IOException;
-import javax.naming.directory.NoSuchAttributeException;
 
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
-import jdk.jfr.RecordingState;
 
 public class VectorizedEscapeScanner implements EscapeScanner {
     public static EscapeScanner.ScalarEscapeScanner FALLBACK = new EscapeScanner.ScalarEscapeScanner(StringEncoder.ESCAPE_TABLE);
@@ -29,11 +27,10 @@ public class VectorizedEscapeScanner implements EscapeScanner {
 
         while ((state.ptr + state.pos) + species.length() < state.len) {
             ByteVector chunk = ByteVector.fromArray(species, state.ptrBytes, state.ptr + state.pos);
-            ByteVector zero = ByteVector.broadcast(species, 0);
 
             // bytes are unsigned in java, so we need to check for negative values
             // to determine if we have a byte that is less than 0 (>= 128).
-            VectorMask<Byte> negative = zero.lt(chunk);
+            VectorMask<Byte> negative = ByteVector.zero(species).lt(chunk);
 
             VectorMask<Byte> tooLowOrDblQuote = chunk.lanewise(VectorOperators.XOR, ByteVector.broadcast(species, 2))
                 .lt(ByteVector.broadcast(species, 33));

--- a/java/src/json/ext/VectorizedEscapeScanner.java
+++ b/java/src/json/ext/VectorizedEscapeScanner.java
@@ -1,0 +1,57 @@
+package json.ext;
+
+import java.io.IOException;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+public class VectorizedEscapeScanner implements EscapeScanner {
+    public static EscapeScanner.ScalarEscapeScanner FALLBACK = new EscapeScanner.ScalarEscapeScanner(StringEncoder.ESCAPE_TABLE);
+
+    // private VectorMask<Byte> needsEscape = null;
+    // private int chunkStart = 0;
+
+    @Override
+    public boolean scan(State state) throws IOException {
+        VectorSpecies<Byte> species = ByteVector.SPECIES_PREFERRED;
+        
+        // if (needsEscape != null) {
+        //     if (needsEscape.anyTrue()) {
+        //         int firstEscapeIndex = needsEscape.firstTrue();
+        //         needsEscape = needsEscape.andNot(VectorMask.fromLong(species, 1L << firstEscapeIndex));
+        //         state.pos = chunkStart + firstEscapeIndex;
+        //         return true;
+        //     } else {
+        //         needsEscape = null;
+        //     }
+        // }
+
+        while ((state.ptr + state.pos) + species.length() < state.len) {
+            ByteVector chunk = ByteVector.fromArray(species, state.ptrBytes, state.ptr + state.pos);
+            ByteVector zero = ByteVector.broadcast(species, 0);
+
+            // bytes are unsigned in java, so we need to check for negative values
+            // to determine if we have a byte that is less than 0 (>= 128).
+            VectorMask<Byte> negative = zero.lt(chunk);
+
+            VectorMask<Byte> tooLowOrDblQuote = chunk.lanewise(VectorOperators.XOR, ByteVector.broadcast(species, 2))
+                .lt(ByteVector.broadcast(species, 33));
+
+            VectorMask<Byte> needsEscape = chunk.eq(ByteVector.broadcast(species, '\\')).or(tooLowOrDblQuote).and(negative);
+            if (needsEscape.anyTrue()) {
+                // chunkStart = state.ptr + state.pos;
+                int firstEscapeIndex = needsEscape.firstTrue();
+                // Clear the bit at firstEscapeIndex to avoid scanning the same byte again
+                // needsEscape = needsEscape.andNot(VectorMask.fromLong(species, 1L << firstEscapeIndex));
+                state.pos += firstEscapeIndex;
+                return true;
+            }
+
+            state.pos += species.length();
+        }
+
+        return FALLBACK.scan(state);
+    }
+}

--- a/java/src/json/ext/VectorizedEscapeScanner.java
+++ b/java/src/json/ext/VectorizedEscapeScanner.java
@@ -1,32 +1,31 @@
 package json.ext;
 
 import java.io.IOException;
+import javax.naming.directory.NoSuchAttributeException;
 
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
+import jdk.jfr.RecordingState;
 
 public class VectorizedEscapeScanner implements EscapeScanner {
     public static EscapeScanner.ScalarEscapeScanner FALLBACK = new EscapeScanner.ScalarEscapeScanner(StringEncoder.ESCAPE_TABLE);
 
-    // private VectorMask<Byte> needsEscape = null;
-    // private int chunkStart = 0;
-
     @Override
-    public boolean scan(State state) throws IOException {
+    public boolean scan(State _state) throws IOException {
         VectorSpecies<Byte> species = ByteVector.SPECIES_PREFERRED;
         
-        // if (needsEscape != null) {
-        //     if (needsEscape.anyTrue()) {
-        //         int firstEscapeIndex = needsEscape.firstTrue();
-        //         needsEscape = needsEscape.andNot(VectorMask.fromLong(species, 1L << firstEscapeIndex));
-        //         state.pos = chunkStart + firstEscapeIndex;
-        //         return true;
-        //     } else {
-        //         needsEscape = null;
-        //     }
-        // }
+        VectorizedState state = (VectorizedState) _state;
+
+        if (state.hasMatches) {
+            if (state.mask > 0) {
+                return nextMatch(state);
+            } else {
+                state.hasMatches = false;
+                state.pos = state.chunkStart + species.length();
+            }
+        }
 
         while ((state.ptr + state.pos) + species.length() < state.len) {
             ByteVector chunk = ByteVector.fromArray(species, state.ptrBytes, state.ptr + state.pos);
@@ -41,17 +40,41 @@ public class VectorizedEscapeScanner implements EscapeScanner {
 
             VectorMask<Byte> needsEscape = chunk.eq(ByteVector.broadcast(species, '\\')).or(tooLowOrDblQuote).and(negative);
             if (needsEscape.anyTrue()) {
-                // chunkStart = state.ptr + state.pos;
-                int firstEscapeIndex = needsEscape.firstTrue();
-                // Clear the bit at firstEscapeIndex to avoid scanning the same byte again
-                // needsEscape = needsEscape.andNot(VectorMask.fromLong(species, 1L << firstEscapeIndex));
-                state.pos += firstEscapeIndex;
-                return true;
+                state.hasMatches = true;
+                state.chunkStart = state.ptr + state.pos;
+                state.mask = needsEscape.toLong();
+
+                return nextMatch(state);
             }
 
             state.pos += species.length();
         }
 
         return FALLBACK.scan(state);
+    }
+
+    private boolean nextMatch(VectorizedState state) {
+        int index = Long.numberOfTrailingZeros(state.mask);
+        state.mask &= (state.mask - 1);
+        state.pos = state.chunkStart + index;
+        return true;
+    }
+
+    @Override
+    public EscapeScanner.State createState(byte[] ptrBytes, int ptr, int len, int beg) {
+        VectorizedState state = new VectorizedState();
+        state.ptrBytes = ptrBytes;
+        state.ptr = ptr;
+        state.len = len;
+        state.beg = beg;
+        state.pos = 0; 
+        return state;
+    }
+
+    private static class VectorizedState extends State {
+        private long mask;
+        private int chunkStart = 0;
+        // private int lastMatchingIndex;
+        private boolean hasMatches;
     }
 }

--- a/java/src/json/ext/VectorizedEscapeScanner.java
+++ b/java/src/json/ext/VectorizedEscapeScanner.java
@@ -30,12 +30,12 @@ class VectorizedEscapeScanner implements EscapeScanner {
 
             // bytes are unsigned in java, so we need to check for negative values
             // to determine if we have a byte that is less than 0 (>= 128).
-            VectorMask<Byte> negative = ByteVector.zero(species).lt(chunk);
+            VectorMask<Byte> nonNegative = ByteVector.zero(species).lt(chunk);
 
             VectorMask<Byte> tooLowOrDblQuote = chunk.lanewise(VectorOperators.XOR, ByteVector.broadcast(species, 2))
                 .lt(ByteVector.broadcast(species, 33));
 
-            VectorMask<Byte> needsEscape = chunk.eq(ByteVector.broadcast(species, '\\')).or(tooLowOrDblQuote).and(negative);
+            VectorMask<Byte> needsEscape = chunk.eq(ByteVector.broadcast(species, '\\')).or(tooLowOrDblQuote).and(nonNegative);
             if (needsEscape.anyTrue()) {
                 state.hasMatches = true;
                 state.chunkStart = state.ptr + state.pos;

--- a/java/src/json/ext/VectorizedEscapeScanner.java
+++ b/java/src/json/ext/VectorizedEscapeScanner.java
@@ -1,4 +1,4 @@
-package json.ext.vectorized;
+package json.ext;
 
 import java.io.IOException;
 
@@ -7,7 +7,7 @@ import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
-public class VectorizedEscapeScanner implements EscapeScanner {
+class VectorizedEscapeScanner implements EscapeScanner {
     public static EscapeScanner.ScalarEscapeScanner FALLBACK = new EscapeScanner.ScalarEscapeScanner(StringEncoder.ESCAPE_TABLE);
 
     @Override

--- a/java/src/json/ext/vectorized/VectorizedEscapeScanner.java
+++ b/java/src/json/ext/vectorized/VectorizedEscapeScanner.java
@@ -1,4 +1,4 @@
-package json.ext;
+package json.ext.vectorized;
 
 import java.io.IOException;
 


### PR DESCRIPTION
# PLEASE DO NOT MERGE

## Overview

This PR uses the [jdk.incubator.vector module](https://docs.oracle.com/en/java/javase/20/docs/api/jdk.incubator.vector/jdk/incubator/vector/package-summary.html) as mentioned in [issue #739](https://github.com/ruby/json/issues/739) to accelerate generating JSON with the same algorithm as the C extension. 

The PR as it exists right now, it will attempt to build the `json.ext.VectorizedEscapeScanner` class with a target release of `16`. This is the first version of Java with support for the `jdk.incubator.vector` module. The remaining code is built for Java 1.8. The code will attempt to load the `json.ext.VectorizedEscapeScanner` only if the `json.enableVectorizedEscapeScanner` system property is set to `true` (or `1`). 

I'm not entirely sure how this is packaged / included with JRuby so I'd love @byroot and @headius's (and others?) thought about how to potential package and/or structure the JARs. I did consider adding the `json.ext.VectorizedEscapeScanner` to a separate `generator-vectorized.jar` but I thought I'd solicit feedback before spending any more time on the build / package process.

## Benchmarks

Machine M1 Macbook Air

Note: I've had trouble modifying the `compare.rb` I was using for the C extension to work reliability with the Java extension. I'll probably spend more time trying to get it to work, but as of right now these are pretty raw benchmarks.

Below are two sample runs of the real-world benchmarks. The benchmarks are much more variable then the C extension for some reason. I'm not sure if HotSpot is doing something slightly different per execution.

### Vector API Enabled

```
scott@Scotts-MacBook-Air json % ONLY=json JAVA_OPTS='--add-modules jdk.incubator.vector -Djson.enableVectorizedEscapeScanner=true' ruby -I"lib" benchmark/encoder-realworld.rb
WARNING: Using incubator modules: jdk.incubator.vector
== Encoding activitypub.json (52595 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json     1.384k i/100ms
Calculating -------------------------------------
                json     15.289k (± 0.8%) i/s   (65.41 μs/i) -    153.624k in  10.048481s

== Encoding citm_catalog.json (500298 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json    76.000 i/100ms
Calculating -------------------------------------
                json    753.787 (± 3.6%) i/s    (1.33 ms/i) -      7.524k in   9.997059s

== Encoding twitter.json (466906 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json   173.000 i/100ms
Calculating -------------------------------------
                json      1.751k (± 1.1%) i/s  (571.24 μs/i) -     17.646k in  10.081260s

== Encoding ohai.json (20147 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json     2.390k i/100ms
Calculating -------------------------------------
                json     23.829k (± 0.8%) i/s   (41.97 μs/i) -    239.000k in  10.030503s
```

### Vector API Disabled

```
scott@Scotts-MacBook-Air json % ONLY=json JAVA_OPTS='--add-modules jdk.incubator.vector -Djson.enableVectorizedEscapeScanner=false' ruby -I"lib" benchmark/encoder-realworld.rb
WARNING: Using incubator modules: jdk.incubator.vector
VectorizedEscapeScanner disabled.
== Encoding activitypub.json (52595 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json     1.204k i/100ms
Calculating -------------------------------------
                json     12.937k (± 1.1%) i/s   (77.30 μs/i) -    130.032k in  10.052234s

== Encoding citm_catalog.json (500298 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json    80.000 i/100ms
Calculating -------------------------------------
                json    817.378 (± 1.0%) i/s    (1.22 ms/i) -      8.240k in  10.082058s

== Encoding twitter.json (466906 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json   147.000 i/100ms
Calculating -------------------------------------
                json      1.499k (± 1.3%) i/s  (667.08 μs/i) -     14.994k in  10.004181s

== Encoding ohai.json (20147 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json     2.269k i/100ms
Calculating -------------------------------------
                json     22.366k (± 5.7%) i/s   (44.71 μs/i) -    224.631k in  10.097069s
```

### `master` as of commit `c5af1b68c582335c2a82bbc4bfa5b3e41ead1eba`

```
scott@Scotts-MacBook-Air json % ONLY=json ruby -I"lib" benchmark/encoder-realworld.rb
== Encoding activitypub.json (52595 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json   886.000 i/100ms
Calculating -------------------------------------
                json^C%                                                                                                                   
scott@Scotts-MacBook-Air json % ONLY=json ruby -I"lib" benchmark/encoder-realworld.rb
== Encoding activitypub.json (52595 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json     1.031k i/100ms
Calculating -------------------------------------
                json     10.812k (± 1.3%) i/s   (92.49 μs/i) -    108.255k in  10.014260s

== Encoding citm_catalog.json (500298 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json    82.000 i/100ms
Calculating -------------------------------------
                json    824.921 (± 1.0%) i/s    (1.21 ms/i) -      8.282k in  10.040787s

== Encoding twitter.json (466906 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json   141.000 i/100ms
Calculating -------------------------------------
                json      1.421k (± 0.7%) i/s  (703.85 μs/i) -     14.241k in  10.023979s

== Encoding ohai.json (20147 bytes)
jruby 9.4.12.0 (3.1.4) 2025-02-11 f4ab75096a Java HotSpot(TM) 64-Bit Server VM 21.0.7+8-LTS-245 on 21.0.7+8-LTS-245 +jit [arm64-darwin]
Warming up --------------------------------------
                json     2.274k i/100ms
Calculating -------------------------------------
                json     22.612k (± 0.9%) i/s   (44.22 μs/i) -    227.400k in  10.057516s
```

### Observations

`activitypub.json` and `twitter.json` seem to be consistently faster with the Vector API enabled. `citm_catalog.json` seems consistently a bit slower and `ohai.json` is fairly close to even.