### PR TITLE
Fix JRuby Java extension build on Windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,8 +48,7 @@ desc "Generate parser with ragel"
 task :ragel => [JAVA_PARSER_SRC]
 
 if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
-  require 'java'
-  path_sep = java.lang.System.getProperty("path.separator")
+  path_separator = File::PATH_SEPARATOR
   ENV['JAVA_HOME'] ||= [
     '/usr/local/java/jdk',
     '/usr/lib/jvm/java-6-openjdk',
@@ -57,7 +56,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   ].find { |c| File.directory?(c) }
   if ENV['JAVA_HOME']
     warn " *** JAVA_HOME is set to #{ENV['JAVA_HOME'].inspect}"
-    ENV['PATH'] = ENV['PATH'].split(/path_sep/).unshift(java_path = "#{ENV['JAVA_HOME']}/bin") * path_sep
+    ENV['PATH'] = ENV['PATH'].split(/path_separator/).unshift(java_path = "#{ENV['JAVA_HOME']}/bin") * path_separator
     warn " *** java binaries are assumed to be in #{java_path.inspect}"
   else
     warn " *** JAVA_HOME was not set or could not be guessed!"
@@ -67,7 +66,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   JRUBY_JAR = File.join(CONFIG["libdir"], "jruby.jar")
   if File.exist?(JRUBY_JAR)
     JAVA_SOURCES.each do |src|
-      classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * path_sep
+      classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * path_separator
       obj = src.sub(/\.java\Z/, '.class')
       file obj => src do
         sh 'javac', '-classpath', classpath, '-source', '1.8', '-target', '1.8', src

--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,8 @@ desc "Generate parser with ragel"
 task :ragel => [JAVA_PARSER_SRC]
 
 if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
+  require 'java'
+  path_sep = java.lang.System.getProperty("path.separator")
   ENV['JAVA_HOME'] ||= [
     '/usr/local/java/jdk',
     '/usr/lib/jvm/java-6-openjdk',
@@ -55,7 +57,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   ].find { |c| File.directory?(c) }
   if ENV['JAVA_HOME']
     warn " *** JAVA_HOME is set to #{ENV['JAVA_HOME'].inspect}"
-    ENV['PATH'] = ENV['PATH'].split(/:/).unshift(java_path = "#{ENV['JAVA_HOME']}/bin") * ':'
+    ENV['PATH'] = ENV['PATH'].split(/path_sep/).unshift(java_path = "#{ENV['JAVA_HOME']}/bin") * path_sep
     warn " *** java binaries are assumed to be in #{java_path.inspect}"
   else
     warn " *** JAVA_HOME was not set or could not be guessed!"
@@ -65,7 +67,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
   JRUBY_JAR = File.join(CONFIG["libdir"], "jruby.jar")
   if File.exist?(JRUBY_JAR)
     JAVA_SOURCES.each do |src|
-      classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * ':'
+      classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * path_sep
       obj = src.sub(/\.java\Z/, '.class')
       file obj => src do
         sh 'javac', '-classpath', classpath, '-source', '1.8', '-target', '1.8', src


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/522

When trying to test https://github.com/ruby/json/pull/824 on Windows, I ran into https://github.com/ruby/json/issues/522. The root cause seems to be the path separator is hard-coded to `:` instead of `;` on Windows.

This PR uses `File::PATH_SEPARATOR` as the path separator.