### PR TITLE
Functions defined in headers should be `static inline`

### DIFF
--- a/ext/json/ext/simd/simd.h
+++ b/ext/json/ext/simd/simd.h
@@ -103,7 +103,8 @@ static inline FORCE_INLINE int string_scan_simd_neon(const char **ptr, const cha
     return 0;
 }
 
-uint8x16x4_t load_uint8x16_4(const unsigned char *table) {
+static inline uint8x16x4_t load_uint8x16_4(const unsigned char *table)
+{
   uint8x16x4_t tab;
   tab.val[0] = vld1q_u8(table);
   tab.val[1] = vld1q_u8(table+16);


### PR DESCRIPTION
If `load_uint8x16_4` has an external linkage, it is defined in both `generator` and `parser` extension libraries.
This duplicate symbol causes a linker error when `--with-static-linked-ext` is given, on some platforms.
