### PR TITLE
Remove remaining `quirks_mode` from java code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -286,6 +286,7 @@
 ## 2015-09-11 (2.0.0)
   * Now complies to newest JSON RFC 7159.
   * Implements compatibility to ruby 2.4 integer unification.
+  * Removed support for `quirks_mode` option.
   * Drops support for old rubies whose life has ended, that is rubies < 2.0.
     Also see https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/
   * There were still some mentions of dual GPL licensing in the source, but JSON

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -83,12 +83,6 @@ public class GeneratorState extends RubyObject {
     private boolean asciiOnly = DEFAULT_ASCII_ONLY;
     static final boolean DEFAULT_ASCII_ONLY = false;
     /**
-     * If set to <code>true</code> all JSON values generated might not be
-     * RFC-conform JSON documents.
-     */
-    private boolean quirksMode = DEFAULT_QUIRKS_MODE;
-    static final boolean DEFAULT_QUIRKS_MODE = false;
-    /**
      * If set to <code>true</code> the forward slash will be escaped in
      * json output.
      */
@@ -218,7 +212,6 @@ public class GeneratorState extends RubyObject {
         this.maxNesting = orig.maxNesting;
         this.allowNaN = orig.allowNaN;
         this.asciiOnly = orig.asciiOnly;
-        this.quirksMode = orig.quirksMode;
         this.scriptSafe = orig.scriptSafe;
         this.strict = orig.strict;
         this.bufferInitialLength = orig.bufferInitialLength;


### PR DESCRIPTION
Most is gone since https://github.com/ruby/json/commit/7d2ad6d6556da03300a5aeadeeacaec563435773

Also add a mention to the 2.0.0 changelog that this was the version it was removed.
I had to look through commits for some context behind it, it only showed that is was added in 1.5.4