### PR TITLE
Fix a -Wreturn-type warning

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1848,6 +1848,8 @@ static VALUE cState_allow_duplicate_key_p(VALUE self)
             return Qnil;
         case JSON_RAISE:
             return Qfalse;
+        default:
+            return Qnil;
     }
 }
 


### PR DESCRIPTION
This PR fixes a warning in ruby/ruby builds:

```
../../../../ext/json/generator/generator.c: In function ‘cState_allow_duplicate_key_p’:
../../../../ext/json/generator/generator.c:1852:1: warning: control reaches end of non-void function [-Wreturn-type]
 1852 | }
      | ^
```