### PR TITLE
Import trusted publisher jobs from ruby/psych

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,62 @@
+name: Publish gem to rubygems.org
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'ruby/json'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: rubygems.org
+      url: https://rubygems.org/gems/json
+
+    permissions:
+      contents: write
+      id-token: write
+
+    strategy:
+      matrix:
+        ruby: ["ruby", "jruby"]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+        # https://github.com/rubygems/rubygems/issues/5882
+      - name: Install dependencies and build for JRuby
+        run: |
+          sudo apt install default-jdk maven
+          gem update --system
+          gem install ruby-maven rake-compiler --no-document
+          rake compile
+        if: matrix.ruby == 'jruby'
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1
+
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: matrix.ruby != 'jruby'


### PR DESCRIPTION
I would like to apply signing sigstore to `json` gem.

https://guides.rubygems.org/trusted-publishing/

According to https://segiddins.github.io/are-we-attested-yet/, it is clear that many gems still do not use sigstore including `json`. It improves to protect supply-chain attack in long term.

This PR prepare to use sigstore via `release-gem` workflow. This workflow will trigger to publish, signing and create GH release for ruby and jruby when we push new version tag like `vX.Y.Z`.

@byroot How about this? 

