### PR TITLE
Fix JSON.unsafe_load with proc argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   ```
 * Fix `JSON.generate` `strict: true` mode to also restrict hash keys.
 * Fix `JSON::Coder` to also invoke block for hash keys that aren't strings nor symbols.
+* Fix `JSON.unsafe_load` usage with proc
 
 ### 2025-07-28 (2.13.2)
 

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -662,6 +662,7 @@ module JSON
   #     when Array
   #       obj.map! {|v| deserialize_obj v }
   #     end
+  #     obj
   #   })
   #   pp ruby
   # Output:
@@ -826,6 +827,7 @@ module JSON
   #     when Array
   #       obj.map! {|v| deserialize_obj v }
   #     end
+  #     obj
   #   })
   #   pp ruby
   # Output:

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -703,9 +703,13 @@ module JSON
     if opts[:allow_blank] && (source.nil? || source.empty?)
       source = 'null'
     end
-    result = parse(source, opts)
-    recurse_proc(result, &proc) if proc
-    result
+
+    if proc
+      opts = opts.dup
+      opts[:on_load] = proc.to_proc
+    end
+
+    parse(source, opts)
   end
 
   # :call-seq:


### PR DESCRIPTION
Commit 73d2137fd3ad18e2a524553e80531f434cf26dde (released with version 2.11.0) removes `JSON.recurse_proc` and its the call in `JSON.load`, opting instead to replace the call with the `:on_load` option. However, this is not the only instance of `recurse_proc`, and anyone using `JSON.unsafe_load` with a proc will receive a `NoMethodError`.

It would appear that `JSON.unsafe_load` had no tests whatsoever, causing this failure. 

These commits: 

1. Add tests covering `JSON.unsafe_load`
2. Align`JSON.unsafe_load` with the current behaviour of `JSON.load`
3. Update the documentation to show that the proc must return the object, as the examples as is do not work.