### PR TITLE
Backport `JSONCommonInterfaceTest#test_unsafe_load_default_options`

### DIFF
--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -226,8 +226,8 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     nan_json = '{ "foo": NaN }'
     assert JSON.unsafe_load(nan_json, nil)['foo'].nan?
     assert_equal nil, JSON.unsafe_load(nil, nil)
-    t = Time.now
-    assert_equal t, JSON.unsafe_load(JSON(t))
+    t = Time.new(2025, 9, 3, 14, 50, 0)
+    assert_equal t.to_s, JSON.unsafe_load(JSON(t)).to_s
   end
 
   def test_unsafe_load_with_options


### PR DESCRIPTION
`JSONCommonInterfaceTest#test_unsafe_load_default_options` is failed with the following:

```
  1) Failure:
JSONCommonInterfaceTest#test_unsafe_load_default_options [/path/to/ruby/test/json/json_common_interface_test.rb:230]:
<2025-09-03 14:28:31.293635 +0200> expected but was
<"2025-09-03 14:28:31 +0200">.
```

I'm not sure why that test is different result with only head version of ruby. I fixed the `Time` object and convert to `String` for assertion.

