### PR TITLE
Improve test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development do
   gem "test-unit"
   gem "test-unit-ruby-core"
   gem "all_images", "~> 0" unless RUBY_PLATFORM =~ /java/
+  gem "simplecov", require: false
 end
 
 group :release do

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -73,7 +73,7 @@ module JSON
             if opts[:create_additions] != false
               if class_name = object[JSON.create_id]
                 klass = JSON.deep_const_get(class_name)
-                if (klass.respond_to?(:json_creatable?) && klass.json_creatable?) || klass.respond_to?(:json_create)
+                if klass.respond_to?(:json_creatable?) ? klass.json_creatable? : klass.respond_to?(:json_create)
                   create_additions_warning if create_additions.nil?
                   object = klass.json_create(object)
                 end

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -97,7 +97,7 @@ module JSON
 
   class << self
     def deprecation_warning(message, uplevel = 3) # :nodoc:
-      gem_root = File.expand_path("../../../", __FILE__) + "/"
+      gem_root = File.expand_path("..", __dir__) + "/"
       caller_locations(uplevel, 10).each do |frame|
         if frame.path.nil? || frame.path.start_with?(gem_root) || frame.path.end_with?("/truffle/cext_ruby.rb", ".c")
           uplevel += 1

--- a/lib/json/generic_object.rb
+++ b/lib/json/generic_object.rb
@@ -52,14 +52,6 @@ module JSON
       table
     end
 
-    def [](name)
-      __send__(name)
-    end unless method_defined?(:[])
-
-    def []=(name, value)
-      __send__("#{name}=", value)
-    end unless method_defined?(:[]=)
-
     def |(other)
       self.class[other.to_hash.merge(to_hash)]
     end

--- a/test/json/json_encoding_test.rb
+++ b/test/json/json_encoding_test.rb
@@ -145,19 +145,11 @@ class JSONEncodingTest < Test::Unit::TestCase
   end
 
   def test_invalid_utf8_sequences
-    # Create strings with invalid UTF-8 sequences
     invalid_utf8 = "\xFF\xFF"
-
-    # Test that generating JSON with invalid UTF-8 raises an error
-    # Different JSON implementations may handle this differently,
-    # so we'll check if any exception is raised
-    begin
+    error = assert_raise(JSON::GeneratorError) do
       generate(invalid_utf8)
-      raise "Expected an exception when generating JSON with invalid UTF8"
-    rescue StandardError => e
-      assert true
-      assert_match(%r{source sequence is illegal/malformed utf-8}, e.message)
     end
+    assert_match(%r{source sequence is illegal/malformed utf-8}, error.message)
   end
 
   def test_surrogate_pair_handling

--- a/test/json/json_generic_object_test.rb
+++ b/test/json/json_generic_object_test.rb
@@ -4,7 +4,7 @@ require_relative 'test_helper'
 class JSONGenericObjectTest < Test::Unit::TestCase
 
   def setup
-    if defined?(GenericObject)
+    if defined?(JSON::GenericObject)
       @go = JSON::GenericObject[ :a => 1, :b => 2 ]
     else
       omit("JSON::GenericObject is not available")
@@ -40,10 +40,10 @@ class JSONGenericObjectTest < Test::Unit::TestCase
         )
       assert_equal 1, l.a
       assert_equal @go,
-        l = JSON('{ "a": 1, "b": 2 }', :object_class => GenericObject)
+        l = JSON('{ "a": 1, "b": 2 }', :object_class => JSON::GenericObject)
       assert_equal 1, l.a
-      assert_equal GenericObject[:a => GenericObject[:b => 2]],
-        l = JSON('{ "a": { "b": 2 } }', :object_class => GenericObject)
+      assert_equal JSON::GenericObject[:a => JSON::GenericObject[:b => 2]],
+        l = JSON('{ "a": { "b": 2 } }', :object_class => JSON::GenericObject)
       assert_equal 2, l.a.b
     end
   end
@@ -51,12 +51,12 @@ class JSONGenericObjectTest < Test::Unit::TestCase
   def test_from_hash
     result  = JSON::GenericObject.from_hash(
       :foo => { :bar => { :baz => true }, :quux => [ { :foobar => true } ] })
-    assert_kind_of GenericObject, result.foo
-    assert_kind_of GenericObject, result.foo.bar
+    assert_kind_of JSON::GenericObject, result.foo
+    assert_kind_of JSON::GenericObject, result.foo.bar
     assert_equal   true, result.foo.bar.baz
-    assert_kind_of GenericObject, result.foo.quux.first
+    assert_kind_of JSON::GenericObject, result.foo.quux.first
     assert_equal   true, result.foo.quux.first.foobar
-    assert_equal   true, GenericObject.from_hash(true)
+    assert_equal   true, JSON::GenericObject.from_hash(true)
   end
 
   def test_json_generic_object_load

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -347,7 +347,7 @@ class JSONParserTest < Test::Unit::TestCase
       assert_equal expected_sym, parse('{"a": 1, "a": 2}', symbolize_names: true)
     end
 
-    if RUBY_ENGINE == 'RUBY_ENGINE'
+    if RUBY_ENGINE == 'ruby'
       assert_deprecated_warning(/#{File.basename(__FILE__)}\:#{__LINE__ + 1}/) do
         assert_equal expected, parse('{"a": 1, "a": 2}')
       end

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -397,10 +397,8 @@ class JSONParserTest < Test::Unit::TestCase
     assert_predicate parse('[]', :freeze => true), :frozen?
     assert_predicate parse('"foo"', :freeze => true), :frozen?
 
-    if string_deduplication_available?
-      assert_same(-'foo', parse('"foo"', :freeze => true))
-      assert_same(-'foo', parse('{"foo": 1}', :freeze => true).keys.first)
-    end
+    assert_same(-'foo', parse('"foo"', :freeze => true))
+    assert_same(-'foo', parse('{"foo": 1}', :freeze => true).keys.first)
   end
 
   def test_parse_comments
@@ -793,16 +791,6 @@ class JSONParserTest < Test::Unit::TestCase
   end
 
   private
-
-  def string_deduplication_available?
-    r1 = rand.to_s
-    r2 = r1.dup
-    begin
-      (-r1).equal?(-r2)
-    rescue NoMethodError
-      false # No String#-@
-    end
-  end
 
   def assert_equal_float(expected, actual, delta = 1e-2)
     Array === expected and expected = expected.first

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -635,6 +635,7 @@ class JSONParserTest < Test::Unit::TestCase
   def test_parse_array_custom_non_array_derived_class
     res = parse('[1,2]', :array_class => SubArrayWrapper)
     assert_equal([1,2], res.data)
+    assert_equal(1, res[0])
     assert_equal(SubArrayWrapper, res.class)
     assert res.shifted?
   end
@@ -696,6 +697,7 @@ class JSONParserTest < Test::Unit::TestCase
     def test_parse_object_custom_non_hash_derived_class
       res = parse('{"foo":"bar"}', :object_class => SubOpenStruct)
       assert_equal "bar", res.foo
+      assert_equal "bar", res[:foo]
       assert_equal(SubOpenStruct, res.class)
       assert res.item_set?
     end

--- a/test/json/test_helper.rb
+++ b/test/json/test_helper.rb
@@ -1,5 +1,13 @@
 $LOAD_PATH.unshift(File.expand_path('../../../ext', __FILE__), File.expand_path('../../../lib', __FILE__))
 
+begin
+  require 'simplecov'
+rescue LoadError
+  # Don't fail Ruby's test suite
+else
+  SimpleCov.start
+end
+
 require 'json'
 require 'test/unit'
 


### PR DESCRIPTION
Fix #850 
Paired with @byroot 

We worked on adding test coverage, and along the way we found a few issues:
* `json_create` being called even if `json_creatable?` returns `false`
* `JSON::GenericObject` tests not running and incorrect because they were looking for `::GenericObject`, not `JSON::GenericObject`
* deprecation warning backtraces were ignoring the `test/` directory
* there were shims for very old Ruby versions (`String#@`, `OpenStruct#[]`)