### PR TITLE
Branch coverage & Explicit File Inclusion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,14 @@ include RbConfig
 require 'rake/testtask'
 class UndocumentedTestTask < Rake::TestTask
   def desc(*) end
+
+  def ruby(...)
+    env_was = ENV["JSON_COVERAGE"]
+    ENV["JSON_COVERAGE"] = "1"
+    ret = super
+    ENV["JSON_COVERAGE"] = env_was
+    ret
+  end
 end
 
 PKG_VERSION       = File.foreach(File.join(__dir__, "lib/json/version.rb")) do |line|

--- a/test/json/test_helper.rb
+++ b/test/json/test_helper.rb
@@ -1,19 +1,17 @@
 $LOAD_PATH.unshift(File.expand_path('../../../ext', __FILE__), File.expand_path('../../../lib', __FILE__))
 
-require 'coverage'
+if ENV["JSON_COVERAGE"]
+  # This test helper is loaded inside Ruby's own test suite, so we try to not mess it up.
+  require 'coverage'
 
-branches_supported = Coverage.respond_to?(:supported?) && Coverage.supported?(:branches)
+  branches_supported = Coverage.respond_to?(:supported?) && Coverage.supported?(:branches)
 
-# Coverage module must be started before SimpleCov to work around the cyclic require order.
-# Track both branches and lines, or else SimpleCov misleadingly reports 0/0 = 100% for non-branching files.
-Coverage.start(lines:    true,
-               branches: branches_supported)
+  # Coverage module must be started before SimpleCov to work around the cyclic require order.
+  # Track both branches and lines, or else SimpleCov misleadingly reports 0/0 = 100% for non-branching files.
+  Coverage.start(lines:    true,
+                 branches: branches_supported)
 
-begin
   require 'simplecov'
-rescue LoadError
-  # Don't fail Ruby's test suite
-else
   SimpleCov.start do
     # Enabling both coverage types to let SimpleCov know to output them together in reports
     enable_coverage :line


### PR DESCRIPTION
Adds branch test coverage when available; Truffle Ruby [does not](https://github.com/oracle/truffleruby/issues/1636) implement branch coverage yet.

Added a couple of comments to warn about common pitfalls using SimpleCov and to explain the oddity of seemingly starting coverage twice.

Also includes SimpleCov config to explicitly include all known files in order to prevent any files silently missed by relying on the implicit discovery system.

