### PR TITLE
Better handle missing ostruct

### DIFF
--- a/test/json/json_generic_object_test.rb
+++ b/test/json/json_generic_object_test.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 require_relative 'test_helper'
 
-class JSONGenericObjectTest < Test::Unit::TestCase
+# ostruct is required to test JSON::GenericObject
+begin
+  require "ostruct"
+rescue LoadError
+  return
+end
 
+class JSONGenericObjectTest < Test::Unit::TestCase
   def setup
     if defined?(JSON::GenericObject)
       @go = JSON::GenericObject[ :a => 1, :b => 2 ]


### PR DESCRIPTION
In the Ruby test suite, this test class is causing trouble because ostruct is not available. Having an autoload for `JSON::GenericObject` but causing it not to define the constant causes a warning.

See https://github.com/ruby/ruby/commit/0dc1cd407e7775610f2bcaef6c1282369867f91c and https://github.com/ruby/ruby/commit/caa5d8cdd7483647013af5e3d1701b0ed3ec8785 in ruby.

We can skip defining the test class entirely instead when ostruct is not available.