### PR TITLE
[Java] implement a better fix for an out of bounds exception

### DIFF
--- a/java/src/json/ext/SWARBasicStringEncoder.java
+++ b/java/src/json/ext/SWARBasicStringEncoder.java
@@ -23,9 +23,13 @@ public class SWARBasicStringEncoder extends StringEncoder {
         int beg = 0;
         int pos = 0;
 
-        ByteBuffer bb = ByteBuffer.wrap(ptrBytes, 0, len);
-        while (ptr + pos + 8 <= len) {
-            long x = bb.getLong(ptr + pos);
+        // There are optimizations in JRuby where ptr > 0 will be true. For example, if we 
+        // slice a string, the underlying byte array is the same, but the
+        // begin index and real size are different. When reading from the ptrBytes
+        // array, we need to always add ptr to the index.
+        ByteBuffer bb = ByteBuffer.wrap(ptrBytes, ptr, len);
+        while (pos + 8 <= len) {
+            long x = bb.getLong(pos);
             if (skipChunk(x)) {
                 pos += 8;
                 continue;
@@ -43,8 +47,8 @@ public class SWARBasicStringEncoder extends StringEncoder {
             }
         }
 
-        if (ptr + pos + 4 <= len) {
-            int x = bb.getInt(ptr + pos);
+        if (pos + 4 <= len) {
+            int x = bb.getInt(pos);
             if (skipChunk(x)) {
                 pos += 4;
             }


### PR DESCRIPTION
After thinking about https://github.com/ruby/json/issues/859 and the fix https://github.com/ruby/json/pull/860 all day, something didn't feel quite right. After doing some debugging tonight, I realized the fix might defeat some of the SWAR optimizations. 

When creating the `ByteBuffer` like so `ByteBuffer.wrap(ptrBytes, 0, len)`,  we are looking at a different portion of the `ptrBytes` array when `ptr > 0`. While we end up reading the correct chunk with `bb.getLong(ptr + pos)` or `bb.getInt(ptr + pos)`, we may end up terminating the SWAR-optimized loop early.

Consider:

```
irb(main):001> require "json"
irb(main):002> s = "01234567890"
irb(main):003> JSON.dump(s[2..-1])
ptr: 2
ptrBytes.length: 15
ptrBytes: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 0, 0, 0, 0]
len: 9
```

The backing array has a length of 15 bytes but the length of the string is 9 bytes.

The `ByteBuffer` in this case is `[48, 49, 50, 51, 52, 53, 54, 55, 56]` because we start it at index 0. When checking if `ptr + pos + 8 <= len` we get `2 + 0 + 8 <= 9` which is `false`.

We really should be looking at `[50, 51, 52, 53, 54, 55, 56, 57, 48]` assuming we do not offset the bounds check by `ptr`, as we did prior to the fix earlier today.

There are two possible fixes:

1. Initialize the `ByteBuffer` as `ByteBuffer.wrap(ptrBytes, ptr, len)` and remove the `ptr` offset in the bounds checks.
2. Initialize the `ByteBuffer` as `ByteBuffer.wrap(ptrBytes, 0, ptrBytes.length)` and leave the bounds checks offset by `ptr`. 

CC: @headius 
