### PR TITLE
Run jruby-head on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           - { os: ubuntu-latest  , ruby: truffleruby-head }
         exclude:
           - { os: windows-latest, ruby: jruby }
-          - { os: windows-latest, ruby: jruby-head }
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Last few failures on Windows caused by jruby/jruby#9018 were fixed in jruby/ruby#9019.