### PR TITLE
Fix sliced string escaping

### DIFF
--- a/java/src/json/ext/SWARBasicStringEncoder.java
+++ b/java/src/json/ext/SWARBasicStringEncoder.java
@@ -27,9 +27,10 @@ public class SWARBasicStringEncoder extends StringEncoder {
         // slice a string, the underlying byte array is the same, but the
         // begin index and real size are different. When reading from the ptrBytes
         // array, we need to always add ptr to the index.
-        ByteBuffer bb = ByteBuffer.wrap(ptrBytes, ptr, len);
+        ByteBuffer bb = ByteBuffer.wrap(ptrBytes, 0, ptr + len);
+
         while (pos + 8 <= len) {
-            long x = bb.getLong(pos);
+            long x = bb.getLong(ptr + pos);
             if (skipChunk(x)) {
                 pos += 8;
                 continue;
@@ -48,7 +49,7 @@ public class SWARBasicStringEncoder extends StringEncoder {
         }
 
         if (pos + 4 <= len) {
-            int x = bb.getInt(pos);
+            int x = bb.getInt(ptr + pos);
             if (skipChunk(x)) {
                 pos += 4;
             }

--- a/test/json/json_encoding_test.rb
+++ b/test/json/json_encoding_test.rb
@@ -35,6 +35,8 @@ class JSONEncodingTest < Test::Unit::TestCase
     # Ref: https://github.com/ruby/json/issues/859
     s = "01234567890"
     assert_equal '"234567890"', JSON.dump(s[2..-1])
+    s = '01234567890123456789"a"b"c"d"e"f"g"h'
+    assert_equal '"\"a\"b\"c\"d\"e\"f\"g\""', JSON.dump(s[20, 15])
   end
 
   def test_unicode


### PR DESCRIPTION
Fixes #870


```java
bb = ByteBuffer.wrap(array, offset, length);
bb.getLong(); // Reads from offset and increment offset. ByteBuffer's offset is mutable.
bb.getLong(idx); // Reads from idx, not from offset+idx
bb.getLong(offset + idx); // What we need
```

### `ByteBuffer.wrap(array, 0, ptr + len)` vs `ByteBuffer.wrap(array)`
`array.length` does not match `ptr+len` for a sliced string. Specifying `ptr+len` seems more safe.



### Test string
`'01234567890123456789"a"b"c"d"e"f"g"h'[20, 15]`
First 15 bytes don't need escape.
15 = 8 + 4 + 3, which can test getLong, getInt and remaining bytes escaping