### PR TITLE
Preserve unsafe_load defaults with second-argument options

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -698,13 +698,13 @@ module JSON
   #      @attributes={"type"=>"Admin", "password"=>"0wn3d"}>}
   #
   def unsafe_load(source, proc = nil, options = nil)
+    if proc && options.nil? && proc.is_a?(Hash)
+      options = proc
+      proc = nil
+    end
+
     opts = if options.nil?
-      if proc && proc.is_a?(Hash)
-        options, proc = proc, nil
-        options
-      else
-        _unsafe_load_default_options
-      end
+      _unsafe_load_default_options
     else
       _unsafe_load_default_options.merge(options)
     end


### PR DESCRIPTION
## Summary

Normalize a Hash passed as `JSON.unsafe_load`'s second positional argument before applying options, then merge it over the unsafe defaults.

## Reproduction

The second-argument form added in #910 currently replaces the entire default set. External cases show it loses `create_additions`, `allow_blank`, and `allow_nan`: Time additions remain raw hashes and blank/NaN input raises. The candidate preserves all three unless explicitly overridden.

## Verification

- exact-release candidate: 608 tests / 3,438 assertions, zero failures/errors
- current 2.x candidate: 610 tests / 3,473 assertions, zero failures/errors
- three focused failing/passing models
- native extension build/install, 39-path gem inspection and Rails 8.1.3.1 / ActiveSupport JSON round trips

## Compatibility

Only positional-options normalization changes, to match `unsafe_load` defaults and the existing three-argument form. JSON 3's keyword API is unaffected. Prepared with AI-assisted source review; no repository tests or changelog were changed.
