### PR TITLE
Fix SEGV when as_json returns a non-String for an invalid symbol

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1124,15 +1124,6 @@ static void generate_json_fallback(FBuffer *buffer, struct generate_json_data *d
     }
 }
 
-static inline void generate_json_symbol(FBuffer *buffer, struct generate_json_data *data, VALUE obj)
-{
-    if (data->state->strict) {
-        generate_json_string(buffer, data, rb_sym2str(obj));
-    } else {
-        generate_json_fallback(buffer, data, obj);
-    }
-}
-
 static void generate_json_null(FBuffer *buffer, struct generate_json_data *data, VALUE obj)
 {
     fbuffer_append(buffer, "null", 4);
@@ -1218,7 +1209,13 @@ start:
         } else if (RB_FLONUM_P(obj)) {
             generate_json_float(buffer, data, obj);
         } else if (RB_STATIC_SYM_P(obj)) {
-            generate_json_symbol(buffer, data, obj);
+            if (data->state->strict) {
+                obj = rb_sym2str(obj);
+                JSON_ASSERT(RBASIC_CLASS(obj) == rb_cString);
+                goto generate_string;
+            }
+
+            generate_json_fallback(buffer, data, obj);
         } else {
             goto general;
         }
@@ -1239,6 +1236,7 @@ start:
             case T_STRING:
                 if (fallback && klass != rb_cString) goto general;
 
+            generate_string:
                 if (RB_LIKELY(valid_json_string_p(obj))) {
                     raw_generate_json_string(buffer, data, obj);
                 } else if (as_json_called) {
@@ -1250,7 +1248,13 @@ start:
                 }
                 break;
             case T_SYMBOL:
-                generate_json_symbol(buffer, data, obj);
+                if (data->state->strict) {
+                    obj = rb_sym2str(obj);
+                    JSON_ASSERT(RBASIC_CLASS(obj) == rb_cString);
+                    goto generate_string;
+                }
+
+                generate_json_fallback(buffer, data, obj);
                 break;
             case T_FLOAT:
                 if (fallback && klass != rb_cFloat) goto general;

--- a/test/json/json_coder_test.rb
+++ b/test/json/json_coder_test.rb
@@ -137,6 +137,33 @@ class JSONCoderTest < Test::Unit::TestCase
     assert_equal 2, calls
   end
 
+  def test_json_coder_symbol_invalid_encoding
+    symbol = "\xFF".b.to_sym
+
+    calls = 0
+    coder = JSON::Coder.new do |object, is_key|
+      calls += 1
+      object.bytes
+    end
+
+    assert_equal "[[255]]", coder.dump([symbol])
+    assert_equal 1, calls
+
+    coder = JSON::Coder.new { |object, is_key| nil }
+    assert_equal "[null]", coder.dump([symbol])
+
+    coder = JSON::Coder.new { |object, is_key| Object.new }
+    assert_raise(JSON::GeneratorError) { coder.dump([symbol]) }
+
+    if RUBY_ENGINE == "ruby"
+      coder = JSON::Coder.new { |object, is_key| symbol }
+      error = assert_raise JSON::GeneratorError do
+        coder.dump([symbol])
+      end
+      assert_equal "source sequence is illegal/malformed utf-8", error.message
+    end
+  end
+
   def test_depth
     coder = JSON::Coder.new(object_nl: "\n", array_nl: "\n", space: " ", indent: "  ", depth: 1)
     assert_equal %({\n    "foo": 42\n  }), coder.dump(foo: 42)


### PR DESCRIPTION
In strict mode, a Symbol whose name is not UTF-8 compatible reached `raw_generate_json_string` together with whatever `as_json` returned, so a non-String result was read as a String. Depending on the heap layout that either segfaults or copies unrelated heap memory into the generated JSON, and the string path failed the same way once `as_json` returned another invalid symbol.

Strict symbols now go through the `T_STRING` case of `generate_json_general`, which already re-dispatches an `as_json` result by type and uses its `as_json_called` flag to stop a returned symbol from recursing.

## Reproduction

```ruby
require "json"

coder = JSON::Coder.new { |object, _| object.is_a?(String) ? object.bytes : object }
p coder.dump(["\xFF".b.to_sym])
```

Over 10 runs on json 2.21.2 with CRuby 4.0.6, this segfaulted 8 times:

```
common.rb:1089: [BUG] Segmentation fault at 0x0000000000000000
```

The other 2 runs printed heap memory instead of crashing, here with unrelated interpreter strings visible inside the JSON string:

```
"[\"\\u0007\xA8\\u0002...can't get const \\u0000Module#ruby2_keywords\\u0000...
...https://github.com/ruby/ruby2_keywords\\u0000...lib/ruby2_keywords.rb...\"]"
```

json 2.18.0, 2.19.3, 2.20.0, 2.21.1 and 2.21.2 all crash on the same input. With this change the script prints `"[[255]]"`, matching what the equivalent plain string already produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
